### PR TITLE
[no-ticket] Adding psycopg2-binary for flask services

### DIFF
--- a/services/events/requirements.txt
+++ b/services/events/requirements.txt
@@ -2,6 +2,7 @@ Flask==1.0.2
 Flask-Script==2.0.6
 Flask-SQLAlchemy==2.3.2
 psycopg2==2.7.4
+psycopg2-binary==2.7.4
 Flask-Testing==0.7.1
 gunicorn==19.8.1
 coverage==4.5.1

--- a/services/users/requirements.txt
+++ b/services/users/requirements.txt
@@ -2,6 +2,7 @@ Flask==1.0.2
 Flask-Script==2.0.6
 Flask-SQLAlchemy==2.3.2
 psycopg2==2.7.4
+psycopg2-binary==2.7.4
 Flask-Testing==0.7.1
 gunicorn==19.8.1
 coverage==4.5.1


### PR DESCRIPTION
### What's Changed

Resolves a error occurring in flask services due to bumping to psycopg2==2.7.4