### PR TITLE
[no-ticket] Lowering docker-compose version to latest supported travis version

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,4 +1,4 @@
-version: '3.4'
+version: '3.2'
 
 services:
 
@@ -29,7 +29,7 @@ services:
     volumes:
       - './services/events:/usr/src/app'
     ports:
-      - 5002:5000
+      - 6000:6000
     environment:
       - SECRET_KEY=my_precious
       - APP_SETTINGS=project.config.DevelopmentConfig

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -1,4 +1,4 @@
-version: '3.4'
+version: '3.2'
 
 services:
 
@@ -38,7 +38,7 @@ services:
     volumes:
       - './services/events:/usr/src/app'
     ports:
-      - 5002:5000
+      - 6000:6000
     environment:
       - SECRET_KEY=my_precious
       - APP_SETTINGS=project.config.ProductionConfig

--- a/docker-compose-stage.yml
+++ b/docker-compose-stage.yml
@@ -1,4 +1,4 @@
-version: '3.4'
+version: '3.2'
 
 services:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.3'
+version: '3.2'
 
 services:
 


### PR DESCRIPTION
### What's changed

Resolves the following issue

`
travis version in "./docker-compose.yml" is unsupported. You might be seeing this error because you're using the wrong Compose file version. Either specify a supported version ("2.0", "2.1", "3.0", "3.1", "3.2")
`