### PR TITLE
Adding additional fields to events endpoint

### DIFF
--- a/services/events/manage.py
+++ b/services/events/manage.py
@@ -68,6 +68,9 @@ def seed_db():
     created = datetime.utcfromtimestamp(
         1525290524).replace(tzinfo=timezone.utc)
 
+    time = datetime.utcfromtimestamp(
+        1525290524).replace(tzinfo=timezone.utc)
+
     db.session.add(Event(
         id=1,
         name='Meetup name',
@@ -75,7 +78,10 @@ def seed_db():
         status='upcoming',
         photo_url='http://example.com/photo.jpg',
         event_url='http://example.com/id=1',
-        description='A description of the meetup'
+        description='A description of the meetup',
+        group_name='Meetup Group',
+        member_type='Member',
+        time=time
     ))
     db.session.commit()
 

--- a/services/events/project/api/events.py
+++ b/services/events/project/api/events.py
@@ -21,6 +21,9 @@ def index():
         photo_url = request.form['photo_url']
         event_url = request.form['event_url']
         description = request.form['description']
+        group_name = request.form['group_name']
+        member_type = request.form['member_type']
+        time = request.form['time']
 
         event = Event(
             id=id,
@@ -29,7 +32,10 @@ def index():
             status=status,
             photo_url=photo_url,
             event_url=event_url,
-            description=description
+            description=description,
+            group_name=group_name,
+            member_type=member_type,
+            time=time
         )
 
         db.session.add(event)
@@ -72,6 +78,9 @@ def add_event():
     photo_url = post_data.get('photo_url')
     event_url = post_data.get('event_url')
     description = post_data.get('description')
+    group_name = post_data.get('group_name')
+    member_type = post_data.get('member_type')
+    time = post_data.get('time')
 
     try:
         event = Event.query.filter_by(id=id).first()
@@ -80,6 +89,10 @@ def add_event():
             created = datetime.utcfromtimestamp(
                 created).replace(tzinfo=timezone.utc)
 
+            time = int(time) / 1000
+            time = datetime.utcfromtimestamp(
+                time).replace(tzinfo=timezone.utc)
+
             event = Event(
                 id=id,
                 name=name,
@@ -87,7 +100,10 @@ def add_event():
                 status=status,
                 photo_url=photo_url,
                 event_url=event_url,
-                description=description
+                description=description,
+                group_name=group_name,
+                member_type=member_type,
+                time=time
             )
 
             db.session.add(event)
@@ -127,7 +143,10 @@ def get_single_event(event_id):
                     'status': event.status,
                     'photo_url': event.photo_url,
                     'event_url': event.event_url,
-                    'description': event.description
+                    'description': event.description,
+                    'group_name': group_name,
+                    'member_type': member_type,
+                    'time': time
                 }
             }
             return jsonify(response_object), 200

--- a/services/events/project/api/models.py
+++ b/services/events/project/api/models.py
@@ -11,15 +11,18 @@ from project import db
 
 class Event(db.Model):
     __tablename__ = "events"
-    id = db.Column(db.Integer, primary_key=True)
+    id = db.Column(db.String(32), primary_key=True)
     name = db.Column(db.String(128), unique=True, nullable=False)
     created = db.Column(db.DateTime, nullable=False)
     status = db.Column(db.String(20), nullable=False)
     photo_url = db.Column(db.String(256), nullable=False)
     event_url = db.Column(db.String(256), nullable=False)
     description = db.Column(db.String(1024), nullable=False)
+    group_name = db.Column(db.String(128), nullable=False)
+    member_type = db.Column(db.String(128), nullable=False)
+    time = db.Column(db.DateTime, nullable=False)
 
-    def __init__(self, id, name, created, status, photo_url, event_url, description):
+    def __init__(self, id, name, created, status, photo_url, event_url, description, group_name, member_type, time):
         self.id = id
         self.name = name
         self.created = created
@@ -27,6 +30,9 @@ class Event(db.Model):
         self.photo_url = photo_url
         self.event_url = event_url
         self.description = description
+        self.group_name = group_name
+        self.member_type = member_type
+        self.time = time
 
     def to_json(self):
         return {
@@ -36,5 +42,8 @@ class Event(db.Model):
             'status': self.status,
             'photo_url': self.photo_url,
             'event_url': self.event_url,
-            'description': self.description
+            'description': self.description,
+            'group_name': self.group_name,
+            'member_type': self.member_type,
+            'time': self.time
         }

--- a/services/events/project/tests/test_event_model.py
+++ b/services/events/project/tests/test_event_model.py
@@ -14,34 +14,47 @@ class TestEventModel(BaseTestCase):
     def test_add_event(self):
         created = datetime.utcfromtimestamp(
             1525290524).replace(tzinfo=timezone.utc)
+        time = datetime.utcfromtimestamp(
+            1525290524).replace(tzinfo=timezone.utc)
 
         event = add_event(
-            id=int(250383898),
+            id='250383898',
             name='Meetup name',
             created=created,
             status='upcoming',
             photo_url='http://example.com/photo.jpg',
             event_url='http://example.com/id=1',
-            description='A description of the meetup'
+            description='A description of the meetup',
+            group_name='Meetup Group',
+            member_type='Member',
+            time=time
         )
 
-        self.assertEqual(event.id, 250383898)
+        self.assertEqual(event.id, '250383898')
         self.assertEqual(event.name, 'Meetup name')
         self.assertEqual(event.created, datetime(2018, 5, 2, 19, 48, 44))
         self.assertEqual(event.status, 'upcoming')
         self.assertEqual(event.photo_url, 'http://example.com/photo.jpg')
         self.assertEqual(event.event_url, 'http://example.com/id=1')
+        self.assertEqual(event.group_name, 'Meetup Group')
+        self.assertEqual(event.member_type, 'Member')
+        self.assertEqual(event.time, datetime(2018, 5, 2, 19, 48, 44))
 
     def test_to_json(self):
         created = datetime.utcfromtimestamp(
             1525290524).replace(tzinfo=timezone.utc)
+        time = datetime.utcfromtimestamp(
+            1525290524).replace(tzinfo=timezone.utc)
         event = add_event(
-            id=1,
+            id='1',
             name='Meetup name',
             created=created,
             status='upcoming',
             photo_url='http://example.com/photo.jpg',
             event_url='http://example.com/id=1',
-            description='A description of the meetup'
+            description='A description of the meetup',
+            group_name='Meetup Group',
+            member_type='Member',
+            time=time
         )
         self.assertTrue(isinstance(event.to_json(), dict))

--- a/services/events/project/tests/utils.py
+++ b/services/events/project/tests/utils.py
@@ -2,7 +2,7 @@ from project import db
 from project.api.models import Event
 
 
-def add_event(id, name, created, status, photo_url, event_url, description):
+def add_event(id, name, created, status, photo_url, event_url, description, group_name, member_type, time):
     event = Event(
         id=id,
         name=name,
@@ -10,7 +10,10 @@ def add_event(id, name, created, status, photo_url, event_url, description):
         status=status,
         photo_url=photo_url,
         event_url=event_url,
-        description=description
+        description=description,
+        group_name=group_name,
+        member_type=member_type,
+        time=time
     )
     db.session.add(event)
     db.session.commit()


### PR DESCRIPTION
### What's Changed

Adds `group_name`, `member_type`, and `time` to `events` endpoint and updates corresponding tests.