### PR TITLE
Removing unused gh-pages dependency and deploy task

### DIFF
--- a/services/client/package-lock.json
+++ b/services/client/package-lock.json
@@ -4424,56 +4424,6 @@
         "assert-plus": "1.0.0"
       }
     },
-    "gh-pages": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gh-pages/-/gh-pages-1.2.0.tgz",
-      "integrity": "sha512-cGLYAvxtlQ1iTwAS4g7FreZPXoE/g62Fsxln2mmR19mgs4zZI+XJ+wVVUhBFCF/0+Nmvbq+abyTWue1m1BSnmg==",
-      "dev": true,
-      "requires": {
-        "async": "2.6.1",
-        "commander": "2.15.1",
-        "filenamify-url": "1.0.0",
-        "fs-extra": "5.0.0",
-        "globby": "6.1.0",
-        "graceful-fs": "4.1.11",
-        "rimraf": "2.6.2"
-      },
-      "dependencies": {
-        "fs-extra": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
-          "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "jsonfile": "4.0.0",
-            "universalify": "0.1.1"
-          }
-        },
-        "globby": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
-          "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
-          "dev": true,
-          "requires": {
-            "array-union": "1.0.2",
-            "glob": "7.1.2",
-            "object-assign": "4.1.1",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "jsonfile": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11"
-          }
-        }
-      }
-    },
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",

--- a/services/client/package.json
+++ b/services/client/package.json
@@ -24,7 +24,6 @@
     "start": "npm run tailwind:css && react-scripts start",
     "build": "npm run tailwind:css && react-scripts build",
     "predeploy": "npm run build",
-    "deploy": "gh-pages -d build",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject",
     "lint": "eslint --config .eslintrc.json src --ignore-path eslint-ignore-test.txt . && prettier \"src/**/*.js\" --list-different",
@@ -33,7 +32,6 @@
   },
   "devDependencies": {
     "eslint-plugin-babel": "^5.1.0",
-    "gh-pages": "^1.1.0",
     "tailwindcss": "^0.5.1"
   }
 }

--- a/services/client/yarn.lock
+++ b/services/client/yarn.lock
@@ -2974,18 +2974,6 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
-gh-pages@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/gh-pages/-/gh-pages-1.1.0.tgz#738134d8e35e5323b39892cda28b8904e85f24b2"
-  dependencies:
-    async "2.6.0"
-    base64url "^2.0.0"
-    commander "2.11.0"
-    fs-extra "^4.0.2"
-    globby "^6.1.0"
-    graceful-fs "4.1.11"
-    rimraf "^2.6.2"
-
 glob-base@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/glob-base/-/glob-base-0.3.0.tgz#dbb164f6221b1c0b1ccf82aea328b497df0ea3c4"


### PR DESCRIPTION
### What's Changed

Removes unused `gh-pages` dependency

### Technical Description

After some thought, we will want to continue to publish with docker in the short term, with the hope of moving to S3/Cloudfront in the future.