### PR TITLE
Adding sorting and source logos to content events

### DIFF
--- a/services/client/src/components/Content.js
+++ b/services/client/src/components/Content.js
@@ -2,30 +2,66 @@ import React from "react";
 import moment from "moment";
 
 class Content extends React.Component {
-  renderCreatedTime(created) {
-    const formatedCreated = moment.utc(created).toNow();
-    return <span className="text-grey-light italic">{formatedCreated}</span>;
+  renderTime(time) {
+    const now = moment();
+    var eventTime = moment.utc(time);
+
+    if (eventTime.isBefore(now)) {
+      var formatted = eventTime.toNow();
+      return <span className="text-grey-light italic">before {formatted}</span>;
+    } else if (eventTime.isAfter(now)) {
+      var formatted = eventTime.fromNow();
+      return <span className="text-grey-light italic">{formatted}</span>;
+    }
   }
 
-  render() {
-    const { id, name, groupName, created, event_url } = this.props;
+  renderSource(source) {
     const iconStyle = {
       height: "32px",
       fontSize: "1.5em"
     };
+
+    const imageStyle = {
+      maxWidth: "25px",
+      paddingTop: "10px"
+    };
+
+    if (source === "eventbrite") {
+      return (
+        <img
+          style={imageStyle}
+          src="http://adultandchild.org/wp-content/uploads/2014/08/Eventbrite-Icon.png"
+          alt=""
+        />
+      );
+    } else if (source === "meetup") {
+      return (
+        <img
+          style={imageStyle}
+          src="https://assets.materialup.com/uploads/30b4082d-3390-44d6-973e-60ca8972f854/preview"
+          alt=""
+        />
+      );
+    }
+
+    return (
+      <i
+        className="rounded-full mt-2 fa fa-calendar-o"
+        style={iconStyle}
+        alt=""
+      />
+    );
+  }
+
+  render() {
+    const { id, name, groupName, time, event_url, source } = this.props;
 
     return (
       <div
         id={id}
         className="bg-white border border-grey-lightest flex p-2 shadow-light hover:shadow"
       >
-        <div className="ml-2">
-          <i
-            className="rounded-full mt-2 fa fa-calendar-o"
-            style={iconStyle}
-            alt=""
-          />
-        </div>
+        <div className="ml-2">{this.renderSource(source)}</div>
         <div className="w-3/4">
           <div className="ml-4 mt-1">
             <div className="mb-2">
@@ -39,8 +75,14 @@ class Content extends React.Component {
               </a>
             </div>
             <div className="text-xs text-grey">
-              <span style={{ paddingRight: "1rem" }}>{groupName}</span>
-              {this.renderCreatedTime(created)}
+              <span
+                style={{
+                  paddingRight: "1rem"
+                }}
+              >
+                {groupName}
+              </span>
+              {this.renderTime(time)}
             </div>
           </div>
         </div>

--- a/services/client/src/components/Header.js
+++ b/services/client/src/components/Header.js
@@ -17,8 +17,7 @@ class Home extends React.Component {
           <a
             className="text-white no-underline"
             href="https://my-dev-space.com"
-          >
-          </a>
+          />
         </div>
         <ul className="list-reset flex flex-wrap mt-1 ml-4">
           <li className="mr-6">

--- a/services/client/src/pages/Events.js
+++ b/services/client/src/pages/Events.js
@@ -5,6 +5,7 @@ import Content from "../components/Content";
 import Pagination from "../components/Pagination";
 
 import _ from "lodash";
+import moment from "moment";
 
 class Events extends Component {
   constructor(props) {
@@ -25,8 +26,10 @@ class Events extends Component {
     };
     return axios(options)
       .then(res => {
-        const events = res.data.data.events;
-        const sortedEvents = _.orderBy(events, ["time"], ["desc"]);
+        var events = _.map(res.data.data.events, function(item) {
+          return _.extend({}, item, { timestamp: moment(item.time).valueOf() });
+        });
+        var sortedEvents = _.orderBy(events, ["timestamp"], ["asc"]);
         this.setState({ events: sortedEvents });
       })
       .catch(error => {
@@ -42,10 +45,12 @@ class Events extends Component {
         name,
         description,
         created,
+        time,
         event_url,
         photo_url,
         group_name,
-        status
+        status,
+        source
       } = el;
       return (
         <Content
@@ -54,10 +59,12 @@ class Events extends Component {
           name={name}
           description={description}
           created={created}
+          time={time}
           event_url={event_url}
           photo_url={photo_url}
           status={status}
           groupName={group_name}
+          source={source}
         />
       );
     });


### PR DESCRIPTION
### What's changed

Adds client-side sorting by `time` and logos for `eventbrite` and `meetup`

| before  | after   | 
|---|---|
| <img width="1680" alt="screen shot 2018-06-11 at 23 20 11" src="https://user-images.githubusercontent.com/1443700/41260180-4d363d8c-6dce-11e8-9a81-a14099d650f4.png">   |  <img width="1680" alt="screen shot 2018-06-11 at 22 58 14" src="https://user-images.githubusercontent.com/1443700/41260088-f2ee9c2a-6dcd-11e8-83d0-e9b248efd316.png"> | 


