### PR TITLE
[events-service] Adding filter to events query to remove past events

### DIFF
--- a/services/events/project/api/events.py
+++ b/services/events/project/api/events.py
@@ -143,8 +143,12 @@ def get_single_event(event_id):
 @events_blueprint.route("/events", methods=["GET"])
 def get_all_events():
     """Get all events"""
+
+    current_time = datetime.utcnow()
+    events = Event.query.filter(Event.time > current_time).all()
+
     response_object = {
         "status": "success",
-        "data": {"events": [event.to_json() for event in Event.query.all()]},
+        "data": {"events": [event.to_json() for event in events]},
     }
     return jsonify(response_object), 200


### PR DESCRIPTION
### What's Changed

Adds filtering to the `events` GET endpoint to remove past events

| before  | after   | 
|---|---|
| <img width="1680" alt="screen shot 2018-06-13 at 22 43 03" src="https://user-images.githubusercontent.com/1443700/41379937-57803228-6f5b-11e8-8e86-786762a21aae.png">    |  <img width="1680" alt="screen shot 2018-06-13 at 22 42 07" src="https://user-images.githubusercontent.com/1443700/41379951-62fc017c-6f5b-11e8-8f50-9c80a1c3a47e.png"> | 

### Technical Description
The query now filters on the `time` field on the `Event` model using the filter function provided by SQLAlchemy.

Documentation on SQL Alchemy can be found here for further context: http://docs.sqlalchemy.org/en/latest/orm/query.html?highlight=query