### PR TITLE
Adding new relic APM for events service

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -35,6 +35,7 @@ services:
       - APP_SETTINGS=project.config.DevelopmentConfig
       - DATABASE_URL=postgres://postgres:postgres@events-db:5432/events_dev
       - DATABASE_TEST_URL=postgres://postgres:postgres@events-db:5432/events_test
+      - NEW_RELIC_ENVIRONMENT = 'development'
     depends_on:
       - events-db
     links:

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -44,6 +44,9 @@ services:
       - APP_SETTINGS=project.config.ProductionConfig
       - DATABASE_URL=postgres://postgres:postgres@events-db:5432/events_prod
       - DATABASE_TEST_URL=postgres://postgres:postgres@events-db:5432/events_test
+      - NEW_RELIC_ENVIRONMENT = 'production'
+      - NEW_RELIC_APP_NAME = 'Muxer (Production)'
+      - NEW_RELIC_LICENSE_KEY
     depends_on:
       - events-db
     links:

--- a/docker-compose-stage.yml
+++ b/docker-compose-stage.yml
@@ -44,6 +44,9 @@ services:
       - APP_SETTINGS=project.config.StagingConfig
       - DATABASE_URL=postgres://postgres:postgres@events-db:5432/events_stage
       - DATABASE_TEST_URL=postgres://postgres:postgres@events-db:5432/events_test
+      - NEW_RELIC_ENVIRONMENT = 'staging'
+      - NEW_RELIC_APP_NAME = 'Muxer (Staging)'
+      - NEW_RELIC_LICENSE_KEY
     depends_on:
       - events-db
     links:

--- a/docker-push.sh
+++ b/docker-push.sh
@@ -19,6 +19,7 @@ then
   then
     export REACT_APP_USERS_SERVICE_URL="http://my-dev-space-staging-alb-2128504978.us-east-1.elb.amazonaws.com"
     export REACT_APP_EVENTS_SERVICE_URL="http://my-dev-space-staging-alb-2128504978.us-east-1.elb.amazonaws.com"
+    export NEW_RELIC_LICENSE_KEY="$NEW_RELIC_LICENSE_KEY"
   fi
 
   if [ "$TRAVIS_BRANCH" == "production" ]
@@ -27,6 +28,7 @@ then
     export REACT_APP_EVENTS_SERVICE_URL="http://my-dev-space-production-alb-453010484.us-east-1.elb.amazonaws.com"
     export DATABASE_URL="$AWS_RDS_URI"
     export SECRET_KEY="$PRODUCTION_SECRET_KEY"
+    export NEW_RELIC_LICENSE_KEY="$NEW_RELIC_LICENSE_KEY"
   fi
 
   if [ "$TRAVIS_BRANCH" == "staging" ] || [ "$TRAVIS_BRANCH" == "production" ]
@@ -44,7 +46,7 @@ then
     cd ../../../../
 
     cd $EVENTS_DIR
-    docker build -t $EVENTS:$COMMIT -f Dockerfile-$DOCKER_ENV .
+    docker build -t $EVENTS:$COMMIT -f Dockerfile-$DOCKER_ENV --build-arg NEW_RELIC_LICENSE_KEY=$NEW_RELIC_LICENSE_KEY .
     docker tag $EVENTS:$COMMIT $REPO/$EVENTS:$TAG
     docker push $REPO/$EVENTS:$TAG
     cd ../../

--- a/ecs/ecs_events_prod_taskdefinition.json
+++ b/ecs/ecs_events_prod_taskdefinition.json
@@ -28,6 +28,18 @@
         {
           "name": "SECRET_KEY",
           "value": "%s"
+        },
+        {
+          "name": "NEW_RELIC_ENVIRONMENT",
+          "value": "production"
+        },
+        {
+          "name": "NEW_RELIC_APP_NAME",
+          "value": "Muxer (Production)"
+        },
+        {
+          "name": "NEW_RELIC_LICENSE_KEY",
+          "value": "%s"
         }
       ],
       "logConfiguration": {

--- a/ecs/ecs_events_stage_taskdefinition.json
+++ b/ecs/ecs_events_stage_taskdefinition.json
@@ -28,6 +28,14 @@
         {
           "name": "SECRET_KEY",
           "value": "my_precious"
+        },
+        {
+          "name": "NEW_RELIC_ENVIRONMENT",
+          "value": "staging"
+        },
+        {
+          "name": "NEW_RELIC_APP_NAME",
+          "value": "Muxer (Staging)"
         }
       ],
       "links": [
@@ -61,6 +69,10 @@
         {
           "name": "POSTGRES_USER",
           "value": "postgres"
+        },
+        {
+          "name": "NEW_RELIC_LICENSE_KEY",
+          "value": "%s"
         }
       ],
       "logConfiguration": {

--- a/services/client/Dockerfile-dev
+++ b/services/client/Dockerfile-dev
@@ -5,7 +5,7 @@ RUN mkdir /usr/src/app
 WORKDIR /usr/src/app
 
 # install and cache app dependencies
-ADD package.json package-lock.json /usr/src/app
+ADD package.json package-lock.json /usr/src/app/
 RUN cd /usr/src/app && npm install --silent
 
 # add app

--- a/services/events/Dockerfile-dev
+++ b/services/events/Dockerfile-dev
@@ -19,5 +19,10 @@ RUN pip install -r requirements.txt
 # add entrypoint.sh
 ADD ./entrypoint.sh /usr/src/app/entrypoint.sh
 
+# add newrelic config
+ADD ./newrelic.ini /usr/src/app/newrelic.ini
+
 # run server
+
+ENV NEW_RELIC_CONFIG_FILE=newrelic.ini
 CMD ["./entrypoint.sh"]

--- a/services/events/Dockerfile-prod
+++ b/services/events/Dockerfile-prod
@@ -19,5 +19,8 @@ RUN pip install -r requirements.txt
 # add app
 ADD . /usr/src/app
 
+# add newrelic config
+ADD ./newrelic.ini /usr/src/app/newrelic.ini
+
 # run server
-CMD gunicorn -b 0.0.0.0:6000 manage:app
+CMD newrelic-admin run-program gunicorn -b 0.0.0.0:6000 manage:app

--- a/services/events/Dockerfile-stage
+++ b/services/events/Dockerfile-stage
@@ -19,6 +19,9 @@ RUN pip install -r requirements.txt
 # add entrypoint.sh
 ADD ./entrypoint-stage.sh /usr/src/app/entrypoint-stage.sh
 
+# add newrelic config
+ADD ./newrelic.ini /usr/src/app/newrelic.ini
+
 # add app
 ADD . /usr/src/app
 

--- a/services/events/entrypoint-stage.sh
+++ b/services/events/entrypoint-stage.sh
@@ -11,4 +11,4 @@ echo "PostgreSQL started"
 python manage.py recreate_db
 python manage.py seed_db
 
-gunicorn -b 0.0.0.0:6000 manage:app
+newrelic-admin run-program gunicorn -b 0.0.0.0:6000 manage:app

--- a/services/events/entrypoint.sh
+++ b/services/events/entrypoint.sh
@@ -8,4 +8,4 @@ done
 
 echo "PostgreSQL started"
 
-python manage.py runserver -h 0.0.0.0 -p 6000
+newrelic-admin run-program python manage.py runserver -h 0.0.0.0 -p 6000

--- a/services/events/newrelic.ini
+++ b/services/events/newrelic.ini
@@ -1,0 +1,196 @@
+# ---------------------------------------------------------------------------
+
+#
+# This file configures the New Relic Python Agent.
+#
+# The path to the configuration file should be supplied to the function
+# newrelic.agent.initialize() when the agent is being initialized.
+#
+# The configuration file follows a structure similar to what you would
+# find for Microsoft Windows INI files. For further information on the
+# configuration file format see the Python ConfigParser documentation at:
+#
+#    http://docs.python.org/library/configparser.html
+#
+# For further discussion on the behaviour of the Python agent that can
+# be configured via this configuration file see:
+#
+#    http://newrelic.com/docs/python/python-agent-configuration
+#
+
+# ---------------------------------------------------------------------------
+
+# Here are the settings that are common to all environments.
+
+[newrelic]
+
+# When "true", the agent collects performance data about your
+# application and reports this data to the New Relic UI at
+# newrelic.com. This global switch is normally overridden for
+# each environment below.
+monitor_mode = true
+
+# Sets the name of a file to log agent messages to. Useful for
+# debugging any issues with the agent. This is not set by
+# default as it is not known in advance what user your web
+# application processes will run as and where they have
+# permission to write to. Whatever you set this to you must
+# ensure that the permissions for the containing directory and
+# the file itself are correct, and that the user that your web
+# application runs as can write to the file. If not able to
+# write out a log file, it is also possible to say "stderr" and
+# output to standard error output. This would normally result in
+# output appearing in your web server log.
+#log_file = /tmp/newrelic-python-agent.log
+
+# Sets the level of detail of messages sent to the log file, if
+# a log file location has been provided. Possible values, in
+# increasing order of detail, are: "critical", "error", "warning",
+# "info" and "debug". When reporting any agent issues to New
+# Relic technical support, the most useful setting for the
+# support engineers is "debug". However, this can generate a lot
+# of information very quickly, so it is best not to keep the
+# agent at this level for longer than it takes to reproduce the
+# problem you are experiencing.
+log_level = info
+
+# The Python Agent communicates with the New Relic service using
+# SSL by default. Note that this does result in an increase in
+# CPU overhead, over and above what would occur for a non SSL
+# connection, to perform the encryption involved in the SSL
+# communication. This work is though done in a distinct thread
+# to those handling your web requests, so it should not impact
+# response times. You can if you wish revert to using a non SSL
+# connection, but this will result in information being sent
+# over a plain socket connection and will not be as secure.
+ssl = true
+
+# High Security Mode enforces certain security settings, and
+# prevents them from being overridden, so that no sensitive data
+# is sent to New Relic. Enabling High Security Mode means that
+# SSL is turned on, request parameters are not collected, and SQL
+# can not be sent to New Relic in its raw form. To activate High
+# Security Mode, it must be set to 'true' in this local .ini
+# configuration file AND be set to 'true' in the server-side
+# configuration in the New Relic user interface. For details, see
+# https://docs.newrelic.com/docs/subscriptions/high-security
+high_security = false
+
+# The Python Agent will attempt to connect directly to the New
+# Relic service. If there is an intermediate firewall between
+# your host and the New Relic service that requires you to use a
+# HTTP proxy, then you should set both the "proxy_host" and
+# "proxy_port" settings to the required values for the HTTP
+# proxy. The "proxy_user" and "proxy_pass" settings should
+# additionally be set if proxy authentication is implemented by
+# the HTTP proxy. The "proxy_scheme" setting dictates what
+# protocol scheme is used in talking to the HTTP proxy. This
+# would normally always be set as "http" which will result in the
+# agent then using a SSL tunnel through the HTTP proxy for end to
+# end encryption.
+# proxy_scheme = http
+# proxy_host = hostname
+# proxy_port = 8080
+# proxy_user =
+# proxy_pass =
+
+# Capturing request parameters is off by default. To enable the
+# capturing of request parameters, first ensure that the setting
+# "attributes.enabled" is set to "true" (the default value), and
+# then add "request.parameters.*" to the "attributes.include"
+# setting. For details about attributes configuration, please
+# consult the documentation.
+# attributes.include = request.parameters.*
+
+# The transaction tracer captures deep information about slow
+# transactions and sends this to the UI on a periodic basis. The
+# transaction tracer is enabled by default. Set this to "false"
+# to turn it off.
+transaction_tracer.enabled = true
+
+# Threshold in seconds for when to collect a transaction trace.
+# When the response time of a controller action exceeds this
+# threshold, a transaction trace will be recorded and sent to
+# the UI. Valid values are any positive float value, or (default)
+# "apdex_f", which will use the threshold for a dissatisfying
+# Apdex controller action - four times the Apdex T value.
+transaction_tracer.transaction_threshold = apdex_f
+
+# When the transaction tracer is on, SQL statements can
+# optionally be recorded. The recorder has three modes, "off"
+# which sends no SQL, "raw" which sends the SQL statement in its
+# original form, and "obfuscated", which strips out numeric and
+# string literals.
+transaction_tracer.record_sql = obfuscated
+
+# Threshold in seconds for when to collect stack trace for a SQL
+# call. In other words, when SQL statements exceed this
+# threshold, then capture and send to the UI the current stack
+# trace. This is helpful for pinpointing where long SQL calls
+# originate from in an application.
+transaction_tracer.stack_trace_threshold = 0.5
+
+# Determines whether the agent will capture query plans for slow
+# SQL queries. Only supported in MySQL and PostgreSQL. Set this
+# to "false" to turn it off.
+transaction_tracer.explain_enabled = true
+
+# Threshold for query execution time below which query plans
+# will not not be captured. Relevant only when "explain_enabled"
+# is true.
+transaction_tracer.explain_threshold = 0.5
+
+# Space separated list of function or method names in form
+# 'module:function' or 'module:class.function' for which
+# additional function timing instrumentation will be added.
+transaction_tracer.function_trace =
+
+# The error collector captures information about uncaught
+# exceptions or logged exceptions and sends them to UI for
+# viewing. The error collector is enabled by default. Set this
+# to "false" to turn it off.
+error_collector.enabled = true
+
+# To stop specific errors from reporting to the UI, set this to
+# a space separated list of the Python exception type names to
+# ignore. The exception name should be of the form 'module:class'.
+error_collector.ignore_errors =
+
+# Browser monitoring is the Real User Monitoring feature of the UI.
+# For those Python web frameworks that are supported, this
+# setting enables the auto-insertion of the browser monitoring
+# JavaScript fragments.
+browser_monitoring.auto_instrument = true
+
+# A thread profiling session can be scheduled via the UI when
+# this option is enabled. The thread profiler will periodically
+# capture a snapshot of the call stack for each active thread in
+# the application to construct a statistically representative
+# call tree.
+thread_profiler.enabled = true
+
+# ---------------------------------------------------------------------------
+
+#
+# The application environments. These are specific settings which
+# override the common environment settings. The settings related to a
+# specific environment will be used when the environment argument to the
+# newrelic.agent.initialize() function has been defined to be either
+# "development", "test", "staging" or "production".
+#
+
+[newrelic:development]
+monitor_mode = false
+
+[newrelic:test]
+monitor_mode = false
+
+[newrelic:staging]
+app_name = Muxer (Staging)
+monitor_mode = true
+
+[newrelic:production]
+app_name = Muxer (Production)
+monitor_mode = true
+
+# ---------------------------------------------------------------------------

--- a/services/events/requirements.txt
+++ b/services/events/requirements.txt
@@ -12,3 +12,4 @@ flask-migrate==2.2.1
 flask-bcrypt==0.7.1
 pyjwt==1.6.4
 black==18.6b4
+newrelic==2.84.0.64


### PR DESCRIPTION
### What's Changed

Adds new relic APM for events service

<img width="1573" alt="screen shot 2018-06-29 at 00 02 26" src="https://user-images.githubusercontent.com/1443700/42065028-99002164-7b30-11e8-8bc7-f52ae2b800d1.png">

### Technical Description

Adds the new relic APM for staging and production environments; by default development and testing, environments will not log metrics to datalog unless explicitly disabled.