### PR TITLE
Bumping python docker image from 3.6.3 to 3.6.6

### DIFF
--- a/services/events/Dockerfile-dev
+++ b/services/events/Dockerfile-dev
@@ -1,4 +1,4 @@
-FROM python:3.6.3
+FROM python:3.6.6
 
 # install environment dependencies
 RUN apt-get update -yqq \

--- a/services/events/Dockerfile-prod
+++ b/services/events/Dockerfile-prod
@@ -1,4 +1,4 @@
-FROM python:3.6.3
+FROM python:3.6.6
 
 # install environment dependencies
 RUN apt-get update -yqq \

--- a/services/events/Dockerfile-stage
+++ b/services/events/Dockerfile-stage
@@ -1,4 +1,4 @@
-FROM python:3.6.3
+FROM python:3.6.6
 
 # install environment dependencies
 RUN apt-get update -yqq \

--- a/services/users/Dockerfile-dev
+++ b/services/users/Dockerfile-dev
@@ -1,4 +1,4 @@
-FROM python:3.6.3
+FROM python:3.6.6
 
 # install environment dependencies
 RUN apt-get update -yqq \

--- a/services/users/Dockerfile-prod
+++ b/services/users/Dockerfile-prod
@@ -1,4 +1,4 @@
-FROM python:3.6.3
+FROM python:3.6.6
 
 # install environment dependencies
 RUN apt-get update -yqq \

--- a/services/users/Dockerfile-stage
+++ b/services/users/Dockerfile-stage
@@ -1,4 +1,4 @@
-FROM python:3.6.3
+FROM python:3.6.6
 
 # install environment dependencies
 RUN apt-get update -yqq \


### PR DESCRIPTION
### What's Changed

Bumps the python docker image used within the `users` and `events` services from `3.6.3` to the latest `3.6.6`.