### PR TITLE
Python users listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ $ docker-compose -f docker-compose-dev.yml run client npm run lint
 
 ###### `users-service`
 ```bash
-$ docker-compose -f docker-compose-dev.yml run users-service flake8 project
+$ docker-compose -f docker-compose-dev.yml run user-service py.test --black --pep8 --flakes -vv --mccabe --cov=project --cov-report=term-missing --junitxml=test-results/results.xml
 ```
 
 ###### `events-service`

--- a/services/users/.flake8
+++ b/services/users/.flake8
@@ -1,2 +1,0 @@
-[flake8]
-max-line-length = 88

--- a/services/users/project/api/auth.py
+++ b/services/users/project/api/auth.py
@@ -1,6 +1,3 @@
-# services/users/project/api/auth.py
-
-
 from flask import Blueprint, jsonify, request
 from sqlalchemy import exc, or_
 
@@ -41,8 +38,7 @@ def register_user():
         else:
             response_object["message"] = "Sorry. That user already exists."
             return jsonify(response_object), 400
-    # handler errors
-    except (exc.IntegrityError, ValueError) as e:
+    except (exc.IntegrityError, ValueError):
         db.session.rollback()
         return jsonify(response_object), 400
 
@@ -69,7 +65,7 @@ def login_user():
         else:
             response_object["message"] = "User does not exist."
             return jsonify(response_object), 404
-    except Exception as e:
+    except Exception:
         response_object["message"] = "Try again."
         return jsonify(response_object), 500
 

--- a/services/users/project/api/models.py
+++ b/services/users/project/api/models.py
@@ -1,10 +1,6 @@
-# services/users/project/api/models.py
-
-
 import datetime
 
 import jwt
-
 from flask import current_app
 
 from project import db, bcrypt
@@ -38,12 +34,13 @@ class User(db.Model):
     def encode_auth_token(self, user_id):
         """Generates the auth token"""
         try:
+            now = datetime.datetime.utcnow()
+            expiry = datetime.timedelta(
+                days=current_app.config.get("TOKEN_EXPIRATION_DAYS"),
+                seconds=current_app.config.get("TOKEN_EXPIRATION_SECONDS"),
+            )
             payload = {
-                "exp": datetime.datetime.utcnow()
-                + datetime.timedelta(
-                    days=current_app.config.get("TOKEN_EXPIRATION_DAYS"),
-                    seconds=current_app.config.get("TOKEN_EXPIRATION_SECONDS"),
-                ),
+                "exp": (now + expiry),
                 "iat": datetime.datetime.utcnow(),
                 "sub": user_id,
             }

--- a/services/users/project/api/users.py
+++ b/services/users/project/api/users.py
@@ -1,6 +1,3 @@
-# services/users/project/api/users.py
-
-
 from sqlalchemy import exc
 from flask import Blueprint, jsonify, request, render_template
 
@@ -53,10 +50,10 @@ def add_user(resp):
         else:
             response_object["message"] = "Sorry. That email already exists."
             return jsonify(response_object), 400
-    except exc.IntegrityError as e:
+    except exc.IntegrityError:
         db.session.rollback()
         return jsonify(response_object), 400
-    except (exc.IntegrityError, ValueError) as e:
+    except (exc.IntegrityError, ValueError):
         db.session.rollback()
         return jsonify(response_object), 400
 

--- a/services/users/pytest.ini
+++ b/services/users/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+pep8maxlinelength = 119
+testpaths = project project/tests

--- a/services/users/requirements.txt
+++ b/services/users/requirements.txt
@@ -1,14 +1,23 @@
+# runtime dependencies
 Flask==1.0.2
 Flask-Script==2.0.6
 Flask-SQLAlchemy==2.3.2
 psycopg2==2.7.5
 psycopg2-binary==2.7.5
-Flask-Testing==0.7.1
 gunicorn==19.8.1
-coverage==4.5.1
-flake8==3.5.0
 flask-cors==3.0.6
 flask-migrate==2.2.1
 flask-bcrypt==0.7.1
-pyjwt==1.6.1
-black==18.6b4
+pyjwt==1.6.4
+newrelic==2.84.0.64
+
+# testing dependencies
+black==18.6b2
+Flask-Testing==0.7.1
+pytest==3.6.2
+pytest-cov==2.5.1
+pytest-flakes==3.0.2
+pytest-mccabe==0.1
+pytest-pep8==1.0.6
+pytest-black==0.1.6
+pytest-pythonpath==0.7.2

--- a/test.sh
+++ b/test.sh
@@ -24,7 +24,7 @@ inspect() {
 
 docker-compose -f $file run users-service python manage.py test
 inspect $? users
-docker-compose -f $file run users-service flake8 project
+docker-compose -f $file run users-service py.test --black --pep8 --flakes -vv --mccabe --cov=project --cov-report=term-missing --junitxml=test-results/results.xml
 docker-compose -f $file run events-service py.test --black --pep8 --flakes -vv --mccabe --cov=project --cov-report=term-missing --junitxml=test-results/results.xml
 
 inspect $? users-lint


### PR DESCRIPTION
### What's changed

In order to generate coverage reports, This pr switches from using flake8 to the following: 

```
docker-compose -f docker-compose-dev.yml run users-service py.test --black --pep8 --flakes -vv --mccabe --cov=project --cov-report=term-missing --junitxml=test-results/results.xml 
```

<img width="1680" alt="screen shot 2018-07-01 at 21 38 32" src="https://user-images.githubusercontent.com/1443700/42138573-5d70d618-7d77-11e8-8954-cc713422ca96.png">
