### PR TITLE
Adding new relic APM to users service

### DIFF
--- a/docker-push.sh
+++ b/docker-push.sh
@@ -34,7 +34,7 @@ then
   if [ "$TRAVIS_BRANCH" == "staging" ] || [ "$TRAVIS_BRANCH" == "production" ]
   then
     cd $USERS_DIR
-    docker build -t $USERS:$COMMIT -f Dockerfile-$DOCKER_ENV .
+    docker build -t $USERS:$COMMIT -f Dockerfile-$DOCKER_ENV --build-arg NEW_RELIC_LICENSE_KEY=$NEW_RELIC_LICENSE_KEY .
     docker tag $USERS:$COMMIT $REPO/$USERS:$TAG
     docker push $REPO/$USERS:$TAG
     cd ../../

--- a/ecs/ecs_events_prod_taskdefinition.json
+++ b/ecs/ecs_events_prod_taskdefinition.json
@@ -35,7 +35,7 @@
         },
         {
           "name": "NEW_RELIC_APP_NAME",
-          "value": "Muxer (Production)"
+          "value": "Muxer - Events (Production)"
         },
         {
           "name": "NEW_RELIC_LICENSE_KEY",

--- a/ecs/ecs_events_stage_taskdefinition.json
+++ b/ecs/ecs_events_stage_taskdefinition.json
@@ -35,7 +35,7 @@
         },
         {
           "name": "NEW_RELIC_APP_NAME",
-          "value": "Muxer (Staging)"
+          "value": "Muxer - Events (Staging)"
         }
       ],
       "links": [

--- a/ecs/ecs_users_prod_taskdefinition.json
+++ b/ecs/ecs_users_prod_taskdefinition.json
@@ -28,6 +28,14 @@
         {
           "name": "SECRET_KEY",
           "value": "%s"
+        },
+        {
+          "name": "NEW_RELIC_ENVIRONMENT",
+          "value": "production"
+        },
+        {
+          "name": "NEW_RELIC_APP_NAME",
+          "value": "Muxer - Users (Production)"
         }
       ],
       "logConfiguration": {

--- a/ecs/ecs_users_stage_taskdefinition.json
+++ b/ecs/ecs_users_stage_taskdefinition.json
@@ -28,6 +28,18 @@
         {
           "name": "SECRET_KEY",
           "value": "my_precious"
+        },
+        {
+          "name": "SECRET_KEY",
+          "value": "my_precious"
+        },
+        {
+          "name": "NEW_RELIC_ENVIRONMENT",
+          "value": "staging"
+        },
+        {
+          "name": "NEW_RELIC_APP_NAME",
+          "value": "Muxer - Users (Staging)"
         }
       ],
       "links": [

--- a/services/users/Dockerfile-dev
+++ b/services/users/Dockerfile-dev
@@ -16,6 +16,10 @@ ADD ./requirements.txt /usr/src/app/requirements.txt
 # install requirements
 RUN pip install -r requirements.txt
 
+# add newrelic config
+ADD ./newrelic.ini /usr/src/app/newrelic.ini
+ENV NEW_RELIC_CONFIG_FILE=newrelic.ini
+
 # add entrypoint.sh
 ADD ./entrypoint.sh /usr/src/app/entrypoint.sh
 

--- a/services/users/Dockerfile-prod
+++ b/services/users/Dockerfile-prod
@@ -16,8 +16,12 @@ ADD ./requirements.txt /usr/src/app/requirements.txt
 # install requirements
 RUN pip install -r requirements.txt
 
+# add newrelic config
+ADD ./newrelic.ini /usr/src/app/newrelic.ini
+ENV NEW_RELIC_CONFIG_FILE=newrelic.ini
+
 # add app
 ADD . /usr/src/app
 
 # run server
-CMD gunicorn -b 0.0.0.0:5000 manage:app
+CMD newrelic-admin run-program gunicorn -b 0.0.0.0:5000 manage:app

--- a/services/users/Dockerfile-stage
+++ b/services/users/Dockerfile-stage
@@ -16,6 +16,10 @@ ADD ./requirements.txt /usr/src/app/requirements.txt
 # install requirements
 RUN pip install -r requirements.txt
 
+# add newrelic config
+ADD ./newrelic.ini /usr/src/app/newrelic.ini
+ENV NEW_RELIC_CONFIG_FILE=newrelic.ini
+
 # add entrypoint.sh
 ADD ./entrypoint-stage.sh /usr/src/app/entrypoint-stage.sh
 

--- a/services/users/entrypoint-stage.sh
+++ b/services/users/entrypoint-stage.sh
@@ -11,4 +11,4 @@ echo "PostgreSQL started"
 python manage.py recreate_db
 python manage.py seed_db
 
-gunicorn -b 0.0.0.0:5000 manage:app
+newrelic-admin run-program gunicorn -b 0.0.0.0:5000 manage:app

--- a/services/users/entrypoint.sh
+++ b/services/users/entrypoint.sh
@@ -8,4 +8,4 @@ done
 
 echo "PostgreSQL started"
 
-python manage.py runserver -h 0.0.0.0
+newrelic-admin run-program python manage.py runserver -h 0.0.0.0

--- a/services/users/newrelic.ini
+++ b/services/users/newrelic.ini
@@ -186,11 +186,11 @@ monitor_mode = false
 monitor_mode = false
 
 [newrelic:staging]
-app_name = Muxer - Events (Staging)
+app_name = Muxer - Users (Staging)
 monitor_mode = true
 
 [newrelic:production]
-app_name = Muxer - Events (Production)
+app_name = Muxer - Users (Production)
 monitor_mode = true
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### What's Changed

Adds the New Relic APM to the `users` service.
Updates the `NEW_RELIC_APP_NAME` for the `events` service to avoid metrics appearing under the same namespace.

Closes #31 