### PR TITLE
Updating production DATABASE_URLs for events and users

### DIFF
--- a/docker-push.sh
+++ b/docker-push.sh
@@ -31,7 +31,7 @@ then
     export NEW_RELIC_LICENSE_KEY="$NEW_RELIC_LICENSE_KEY"
   fi
 
-  if [ "$TRAVIS_BRANCH" == "staging" ] || [ "$TRAVIS_BRANCH" == "production" ]
+  if [ "$TRAVIS_BRANCH" == "staging" ]
   then
     cd $USERS_DIR
     docker build -t $USERS:$COMMIT -f Dockerfile-$DOCKER_ENV --build-arg NEW_RELIC_LICENSE_KEY=$NEW_RELIC_LICENSE_KEY .
@@ -47,6 +47,45 @@ then
 
     cd $EVENTS_DIR
     docker build -t $EVENTS:$COMMIT -f Dockerfile-$DOCKER_ENV --build-arg NEW_RELIC_LICENSE_KEY=$NEW_RELIC_LICENSE_KEY .
+    docker tag $EVENTS:$COMMIT $REPO/$EVENTS:$TAG
+    docker push $REPO/$EVENTS:$TAG
+    cd ../../
+
+    cd $EVENTS_DB_DIR
+    docker build -t $EVENTS_DB:$COMMIT -f Dockerfile .
+    docker tag $EVENTS_DB:$COMMIT $REPO/$EVENTS_DB:$TAG
+    docker push $REPO/$EVENTS_DB:$TAG
+    cd ../../../../
+
+    cd $CLIENT_DIR
+    docker build -t $CLIENT:$COMMIT -f Dockerfile-$DOCKER_ENV --build-arg REACT_APP_USERS_SERVICE_URL=$REACT_APP_USERS_SERVICE_URL --build-arg REACT_APP_EVENTS_SERVICE_URL=$REACT_APP_EVENTS_SERVICE_URL .
+    docker tag $CLIENT:$COMMIT $REPO/$CLIENT:$TAG
+    docker push $REPO/$CLIENT:$TAG
+    cd ../../
+
+    cd $SWAGGER_DIR
+    docker build -t $SWAGGER:$COMMIT -f Dockerfile-$DOCKER_ENV .
+    docker tag $SWAGGER:$COMMIT $REPO/$SWAGGER:$TAG
+    docker push $REPO/$SWAGGER:$TAG
+    cd ../../
+  fi
+
+  if [ "$TRAVIS_BRANCH" == "production" ]
+  then
+    cd $USERS_DIR
+    docker build -t $USERS:$COMMIT -f Dockerfile-$DOCKER_ENV --build-arg DATABASE_URL=AWS_RDS_USERS_URI .
+    docker tag $USERS:$COMMIT $REPO/$USERS:$TAG
+    docker push $REPO/$USERS:$TAG
+    cd ../../
+
+    cd $USERS_DB_DIR
+    docker build -t $USERS_DB:$COMMIT -f Dockerfile .
+    docker tag $USERS_DB:$COMMIT $REPO/$USERS_DB:$TAG
+    docker push $REPO/$USERS_DB:$TAG
+    cd ../../../../
+
+    cd $EVENTS_DIR
+    docker build -t $EVENTS:$COMMIT -f Dockerfile-$DOCKER_ENV --build-arg NEW_RELIC_LICENSE_KEY=$NEW_RELIC_LICENSE_KEY --build-arg DATABASE_URL=AWS_RDS_EVENTS_URI .
     docker tag $EVENTS:$COMMIT $REPO/$EVENTS:$TAG
     docker push $REPO/$EVENTS:$TAG
     cd ../../


### PR DESCRIPTION
### What's Changed

Splits the `docker-push.sh` step to deploy to staging or production to allow for greater specificity of DATABASE_URLs for the production environment. 

The staging `DATABASE_URL` remain unchanged and comes from the docker-compose file;

The production URLs are stored as secrets in Travis and passed in as `AWS_RDS_EVENTS_URI` and `AWS_RDS_USERS_URI` as build arguments.

*RDS instances created in AWS*
<img width="1302" alt="screen shot 2018-07-04 at 22 44 31" src="https://user-images.githubusercontent.com/1443700/42294822-1421019c-7fdc-11e8-8fd7-b9b44561d1d7.png">

*Travis CI Secrets keys*
<img width="1046" alt="screen shot 2018-07-04 at 22 46 02" src="https://user-images.githubusercontent.com/1443700/42294838-44f01b14-7fdc-11e8-9c1c-a2468d673428.png">

