### PR TITLE
Adding staging RDS instances for users and events

### DIFF
--- a/docker-deploy-stage.sh
+++ b/docker-deploy-stage.sh
@@ -39,7 +39,7 @@ then
       service="my-dev-space-users-stage-service"
       template="ecs_users_stage_taskdefinition.json"
       task_template=$(cat "ecs/$template")
-      task_def=$(printf "$task_template" $AWS_ACCOUNT_ID $SECRET_KEY $NEW_RELIC_LICENSE_KEY)
+      task_def=$(printf "$task_template" $AWS_ACCOUNT_ID $AWS_RDS_USERS_URI $SECRET_KEY $NEW_RELIC_LICENSE_KEY)
       echo "$task_def"
       register_definition
       update_service
@@ -48,7 +48,7 @@ then
       service="my-dev-space-events-stage-service"
       template="ecs_events_stage_taskdefinition.json"
       task_template=$(cat "ecs/$template")
-      task_def=$(printf "$task_template" $AWS_ACCOUNT_ID $SECRET_KEY $NEW_RELIC_LICENSE_KEY)
+      task_def=$(printf "$task_template" $AWS_ACCOUNT_ID $AWS_RDS_EVENTS_URI $SECRET_KEY $NEW_RELIC_LICENSE_KEY)
       echo "$task_def"
       register_definition
       update_service

--- a/docker-push.sh
+++ b/docker-push.sh
@@ -21,29 +21,19 @@ then
     export REACT_APP_EVENTS_SERVICE_URL="http://my-dev-space-staging-alb-2128504978.us-east-1.elb.amazonaws.com"
     export SECRET_KEY="$STAGING_SECRET_KEY"
     export NEW_RELIC_LICENSE_KEY="$NEW_RELIC_LICENSE_KEY"
+    export AWS_RDS_EVENTS_URI="$AWS_RDS_EVENTS_STAGING_URI"
+    export AWS_RDS_USERS_URI="$AWS_RDS_USERS_STAGING_URI"
     cd $USERS_DIR
     docker build -t $USERS:$COMMIT -f Dockerfile-$DOCKER_ENV .
     docker tag $USERS:$COMMIT $REPO/$USERS:$TAG
     docker push $REPO/$USERS:$TAG
     cd ../../
 
-    cd $USERS_DB_DIR
-    docker build -t $USERS_DB:$COMMIT -f Dockerfile .
-    docker tag $USERS_DB:$COMMIT $REPO/$USERS_DB:$TAG
-    docker push $REPO/$USERS_DB:$TAG
-    cd ../../../../
-
     cd $EVENTS_DIR
     docker build -t $EVENTS:$COMMIT -f Dockerfile-$DOCKER_ENV .
     docker tag $EVENTS:$COMMIT $REPO/$EVENTS:$TAG
     docker push $REPO/$EVENTS:$TAG
     cd ../../
-
-    cd $EVENTS_DB_DIR
-    docker build -t $EVENTS_DB:$COMMIT -f Dockerfile .
-    docker tag $EVENTS_DB:$COMMIT $REPO/$EVENTS_DB:$TAG
-    docker push $REPO/$EVENTS_DB:$TAG
-    cd ../../../../
 
     cd $CLIENT_DIR
     docker build -t $CLIENT:$COMMIT -f Dockerfile-$DOCKER_ENV --build-arg REACT_APP_USERS_SERVICE_URL=$REACT_APP_USERS_SERVICE_URL --build-arg REACT_APP_EVENTS_SERVICE_URL=$REACT_APP_EVENTS_SERVICE_URL .

--- a/ecs/ecs_events_stage_taskdefinition.json
+++ b/ecs/ecs_events_stage_taskdefinition.json
@@ -23,7 +23,7 @@
         },
         {
           "name": "DATABASE_URL",
-          "value": "postgres://postgres:postgres@events-db:5432/events_stage"
+          "value": "%s"
         },
         {
           "name": "SECRET_KEY",
@@ -42,47 +42,10 @@
           "value": "%s"
         }
       ],
-      "links": [
-        "events-db"
-      ],
       "logConfiguration": {
         "logDriver": "awslogs",
         "options": {
           "awslogs-group": "my-dev-space-events-stage",
-          "awslogs-region": "us-east-1"
-        }
-      }
-    },
-    {
-      "name": "events-db",
-      "image": "%s.dkr.ecr.us-east-1.amazonaws.com/my-dev-space-events_db:staging",
-      "essential": true,
-      "memoryReservation": 300,
-      "portMappings": [
-        {
-          "hostPort": 0,
-          "protocol": "tcp",
-          "containerPort": 5432
-        }
-      ],
-      "environment": [
-        {
-          "name": "POSTGRES_PASSWORD",
-          "value": "postgres"
-        },
-        {
-          "name": "POSTGRES_USER",
-          "value": "postgres"
-        },
-        {
-          "name": "NEW_RELIC_LICENSE_KEY",
-          "value": "%s"
-        }
-      ],
-      "logConfiguration": {
-        "logDriver": "awslogs",
-        "options": {
-          "awslogs-group": "my-dev-space-events_db-stage",
           "awslogs-region": "us-east-1"
         }
       }

--- a/ecs/ecs_users_stage_taskdefinition.json
+++ b/ecs/ecs_users_stage_taskdefinition.json
@@ -23,7 +23,7 @@
         },
         {
           "name": "DATABASE_URL",
-          "value": "postgres://postgres:postgres@users-db:5432/users_stage"
+          "value": "%s"
         },
         {
           "name": "SECRET_KEY",
@@ -42,43 +42,10 @@
           "value": "%s"
         }
       ],
-      "links": [
-        "users-db"
-      ],
       "logConfiguration": {
         "logDriver": "awslogs",
         "options": {
           "awslogs-group": "my-dev-space-users-stage",
-          "awslogs-region": "us-east-1"
-        }
-      }
-    },
-    {
-      "name": "users-db",
-      "image": "%s.dkr.ecr.us-east-1.amazonaws.com/my-dev-space-users_db:staging",
-      "essential": true,
-      "memoryReservation": 300,
-      "portMappings": [
-        {
-          "hostPort": 0,
-          "protocol": "tcp",
-          "containerPort": 5432
-        }
-      ],
-      "environment": [
-        {
-          "name": "POSTGRES_PASSWORD",
-          "value": "postgres"
-        },
-        {
-          "name": "POSTGRES_USER",
-          "value": "postgres"
-        }
-      ],
-      "logConfiguration": {
-        "logDriver": "awslogs",
-        "options": {
-          "awslogs-group": "my-dev-space-users_db-stage",
           "awslogs-region": "us-east-1"
         }
       }


### PR DESCRIPTION
### What's Changed

Removes docker Postgres instances of always up RDS instances. This also reduces the build time by no longer requiring these images to be built and pushed to AWS.