### PR TITLE
Adding css loading spinner

### DIFF
--- a/services/client/src/components/spinner/loading.js
+++ b/services/client/src/components/spinner/loading.js
@@ -1,0 +1,18 @@
+import React from "react";
+import styles from "./styles";
+
+const Spinner = () => {
+  return (
+    <React.Fragment>
+      <style jsx>{styles}</style>
+      <div className="loading-container">
+        <div className="lds-ripple">
+          <div></div>
+          <div></div>
+        </div>
+      </div>
+    </React.Fragment>
+  );
+};
+
+export default Spinner;

--- a/services/client/src/components/spinner/styles/index.js
+++ b/services/client/src/components/spinner/styles/index.js
@@ -1,0 +1,41 @@
+import css from "styled-jsx/css";
+
+export default css`
+  .loading-container {
+    margin-left: auto;
+    margin-right: auto;
+    width: 5em
+  }
+  .lds-ripple {
+    display: inline-block;
+    position: relative;
+    width: 64px;
+    height: 64px;
+  }
+  .lds-ripple div {
+    position: absolute;
+    border: 4px solid #3490dc;
+    opacity: 1;
+    border-radius: 50%;
+    animation: lds-ripple 1s cubic-bezier(0.5, 0.2, 0.8, 1) infinite;
+  }
+  .lds-ripple div:nth-child(2) {
+    animation-delay: -0.5s;
+  }
+  @keyframes lds-ripple {
+    0% {
+      top: 28px;
+      left: 28px;
+      width: 0;
+      height: 0;
+      opacity: 1;
+    }
+    100% {
+      top: -1px;
+      left: -1px;
+      width: 58px;
+      height: 58px;
+      opacity: 0;
+    }
+  }
+`;

--- a/services/client/src/pages/events/index.js
+++ b/services/client/src/pages/events/index.js
@@ -3,6 +3,7 @@ import axios from "axios";
 import _ from "lodash";
 import moment from "moment";
 import CallToActionBanner from "components/call-to-action-banner";
+import Spinner from "components/spinner/loading";
 import Event from "components/event";
 
 const updateEventsList = function(eventsList) {
@@ -40,7 +41,7 @@ class Events extends Component {
   renderRecentEvents() {
     const { recentEvents } = this.state;
 
-    if (!_.isArray(recentEvents)) return <div>Loading...</div>;
+    if (!_.isArray(recentEvents)) return <Spinner />;
     if (recentEvents.length === 0) return null;
 
     return (
@@ -55,7 +56,7 @@ class Events extends Component {
   renderUpcomingEvents() {
     const { upcomingEvents } = this.state;
 
-    if (!_.isArray(upcomingEvents)) return <div>Loading...</div>;
+    if (!_.isArray(upcomingEvents)) return null;
 
     return (
       <div>

--- a/services/client/src/pages/videos/index.js
+++ b/services/client/src/pages/videos/index.js
@@ -3,6 +3,7 @@ import axios from "axios";
 import _ from "lodash";
 import moment from "moment";
 import CallToActionBanner from "components/call-to-action-banner";
+import Spinner from "components/spinner/loading";
 import Video from "components/video";
 
 const updateVideosList = function(videosList) {
@@ -39,7 +40,7 @@ class Videos extends Component {
   renderRecentVideos() {
     const { recentVideos } = this.state;
 
-    if (!_.isArray(recentVideos)) return <div>Loading...</div>;
+    if (!_.isArray(recentVideos)) return <Spinner />;
     if (recentVideos.length === 0) return null;
 
     return (


### PR DESCRIPTION
### What's Changed

Adds a css loading spinner to replace the `loading` text. Appears to help with the perceived performance of awaiting the loading results. Future work will help mitigate against long wait times by avoiding subsequent requests.

Before | After
--- | ---
![muxer_loading_spinner_before](https://user-images.githubusercontent.com/1443700/42602380-18652fd2-8561-11e8-9072-933489f18a53.gif) |  ![muxer_loading_spinner_after](https://user-images.githubusercontent.com/1443700/42602382-19ad1a9e-8561-11e8-8974-af05969a4286.gif)
