### PR TITLE
Spike into supporting ical format

### DIFF
--- a/services/events/project/api/events.py
+++ b/services/events/project/api/events.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta
 # 3rd party
 from sqlalchemy import exc, and_
 from flask import Blueprint, jsonify, request
+import ics
 
 # local
 from project.api.models import Event
@@ -162,3 +163,22 @@ def get_all_events():
         },
     }
     return jsonify(response_object), 200
+
+
+@events_blueprint.route("/events.ics", methods=["GET"])
+def get_all_events_as_ics():
+    """Get all events in iCalendar format"""
+
+    upcoming_events = Event.query.filter(Event.time > datetime.utcnow()).all()
+
+    calendar = ics.Calendar()
+    for upcoming_event in upcoming_events:
+        event = ics.Event()
+        event.name = upcoming_event.name
+        event.begin = upcoming_event.time
+        event.duration = timedelta(hours=1)
+        calendar.events.add(event)
+
+    return str(calendar), 200, {
+        'Content-Type': 'text/calendar; charset=utf-8'
+    }

--- a/services/events/requirements.txt
+++ b/services/events/requirements.txt
@@ -10,6 +10,7 @@ flask-migrate==2.2.1
 flask-bcrypt==0.7.1
 pyjwt==1.6.4
 newrelic==3.4.0.95
+ics==0.4
 
 # testing dependencies
 black==18.6b2


### PR DESCRIPTION
We don't yet have all the data to power this, so this is a very small spike into attempting some iCalendar support. We could leave this as an undocumented feature as we develop it out; longer term my hope is that as we add filtering, date ranges, etc. to the main UI, we could also provide this as a corresponding ics endpoint which users could pull into something like Google calendar. This would run in a similar vein to the existing "Belfast Tech Events" ical feed which is available and pulls in meetup.com, farset, etc.