### PR TITLE
event service response limit

### DIFF
--- a/services/events/project/api/events.py
+++ b/services/events/project/api/events.py
@@ -162,7 +162,7 @@ def get_all_events():
             and_(Event.start <= current_time, Event.start >= recent_past)
         )
         .order_by(Event.start)
-        .all()
+        .limit(30)
     )
 
     response_object = {


### PR DESCRIPTION
### What's Changed

Updates the `events` service to return 30 results instead of all events. 

Note: This is a small optimization until pagination is added to the service. Issue opened #300