### PR TITLE
Adding flask-caching to reduce load times

### DIFF
--- a/services/events/Pipfile
+++ b/services/events/Pipfile
@@ -1,11 +1,9 @@
 [[source]]
-
 url = 'https://pypi.python.org/simple'
 verify_ssl = true
 name = 'pypi'
 
 [packages]
-
 Flask = "==1.0.2"
 Flask-Script = "==2.0.6"
 Flask-SQLAlchemy = "==2.3.2"
@@ -16,9 +14,9 @@ flask-migrate = "==2.2.1"
 flask-bcrypt = "==0.7.1"
 pyjwt = "==1.6.4"
 newrelic = "==4.2.0.100"
+flask-caching = "==1.4.0"
 
 [dev-packages]
-
 black = "==18.6b2"
 Flask-Testing = "==0.7.1"
 ipython = "==6.5.0"

--- a/services/events/Pipfile.lock
+++ b/services/events/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "59b547482d706306540721c4ec8802b937fe2d9cf396d7ba0621a9af3b8aa4b1"
+            "sha256": "781ad99134d14d239f92e3430cc11b170048be4618555c94b2aa5fbb6a27339b"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -118,6 +118,14 @@
             ],
             "index": "pypi",
             "version": "==0.7.1"
+        },
+        "flask-caching": {
+            "hashes": [
+                "sha256:44fe827c6cc519d48fb0945fa05ae3d128af9a98f2a6e71d4702fd512534f227",
+                "sha256:e34f24631ba240e09fe6241e1bf652863e0cff06a1a94598e23be526bc2e4985"
+            ],
+            "index": "pypi",
+            "version": "==1.4.0"
         },
         "flask-cors": {
             "hashes": [
@@ -262,9 +270,9 @@
         },
         "sqlalchemy": {
             "hashes": [
-                "sha256:72325e67fb85f6e9ad304c603d83626d1df684fdf0c7ab1f0352e71feeab69d8"
+                "sha256:ef6569ad403520ee13e180e1bfd6ed71a0254192a934ec1dbd3dbf48f4aa9524"
             ],
-            "version": "==1.2.10"
+            "version": "==1.2.11"
         },
         "werkzeug": {
             "hashes": [
@@ -280,7 +288,6 @@
                 "sha256:37228cda29411948b422fae072f57e31d3396d2ee1c9783775980ee9c9990af6",
                 "sha256:58587dd4dc3daefad0487f6d9ae32b4542b185e1c36db6993290e7c41ca2b47c"
             ],
-            "markers": "python_version != '3.2.*' and python_version != '3.1.*' and python_version >= '2.7' and python_version != '3.3.*' and python_version != '3.0.*'",
             "version": "==1.5"
         },
         "appdirs": {
@@ -289,6 +296,14 @@
                 "sha256:d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e"
             ],
             "version": "==1.4.3"
+        },
+        "appnope": {
+            "hashes": [
+                "sha256:5b26757dc6f79a3b7dc9fab95359328d5747fcb2409d331ea66d0272b90ab2a0",
+                "sha256:8b995ffe925347a2138d7ac0fe77155e4311a0ea6d6da4f5128fe4b3cbe5ed71"
+            ],
+            "markers": "sys_platform == 'darwin'",
+            "version": "==0.1.0"
         },
         "atomicwrites": {
             "hashes": [
@@ -330,8 +345,11 @@
             "hashes": [
                 "sha256:03481e81d558d30d230bc12999e3edffe392d244349a90f4ef9b88425fac74ba",
                 "sha256:0b136648de27201056c1869a6c0d4e23f464750fd9a9ba9750b8336a244429ed",
+                "sha256:104ab3934abaf5be871a583541e8829d6c19ce7bde2923b2751e0d3ca44db60a",
                 "sha256:10a46017fef60e16694a30627319f38a2b9b52e90182dddb6e37dcdab0f4bf95",
+                "sha256:15b111b6a0f46ee1a485414a52a7ad1d703bdf984e9ed3c288a4414d3871dcbd",
                 "sha256:198626739a79b09fa0a2f06e083ffd12eb55449b5f8bfdbeed1df4910b2ca640",
+                "sha256:1c383d2ef13ade2acc636556fd544dba6e14fa30755f26812f54300e401f98f2",
                 "sha256:23d341cdd4a0371820eb2b0bd6b88f5003a7438bbedb33688cd33b8eae59affd",
                 "sha256:28b2191e7283f4f3568962e373b47ef7f0392993bb6660d079c62bd50fe9d162",
                 "sha256:2a5b73210bad5279ddb558d9a2bfedc7f4bf6ad7f3c988641d83c40293deaec1",
@@ -354,13 +372,17 @@
                 "sha256:7e1fe19bd6dce69d9fd159d8e4a80a8f52101380d5d3a4d374b6d3eae0e5de9c",
                 "sha256:8c3cb8c35ec4d9506979b4cf90ee9918bc2e49f84189d9bf5c36c0c1119c6558",
                 "sha256:9d6dd10d49e01571bf6e147d3b505141ffc093a06756c60b053a859cb2128b1f",
+                "sha256:9e112fcbe0148a6fa4f0a02e8d58e94470fc6cb82a5481618fea901699bf34c4",
+                "sha256:ac4fef68da01116a5c117eba4dd46f2e06847a497de5ed1d64bb99a5fda1ef91",
+                "sha256:b8815995e050764c8610dbc82641807d196927c3dbed207f0a079833ffcf588d",
                 "sha256:be6cfcd8053d13f5f5eeb284aa8a814220c3da1b0078fa859011c7fffd86dab9",
                 "sha256:c1bb572fab8208c400adaf06a8133ac0712179a334c09224fb11393e920abcdd",
                 "sha256:de4418dadaa1c01d497e539210cb6baa015965526ff5afc078c57ca69160108d",
                 "sha256:e05cb4d9aad6233d67e0541caa7e511fa4047ed7750ec2510d466e806e0255d6",
-                "sha256:f3f501f345f24383c0000395b26b726e46758b71393267aeae0bd36f8b3ade80"
+                "sha256:e4d96c07229f58cb686120f168276e434660e4358cc9cf3b0464210b04913e77",
+                "sha256:f3f501f345f24383c0000395b26b726e46758b71393267aeae0bd36f8b3ade80",
+                "sha256:f8a923a85cb099422ad5a2e345fe877bbc89a8a8b23235824a93488150e45f6e"
             ],
-            "markers": "python_version != '3.2.*' and python_version != '3.1.*' and python_version < '4' and python_version != '3.0.*' and python_version >= '2.6'",
             "version": "==4.5.1"
         },
         "decorator": {
@@ -375,7 +397,6 @@
                 "sha256:a7a84d5fa07a089186a329528f127c9d73b9de57f1a1131b82bb5320ee651f6a",
                 "sha256:fc155a6b553c66c838d1a22dba1dc9f5f505c43285a878c6f74a79c024750b83"
             ],
-            "markers": "python_version != '3.2.*' and python_version != '3.1.*' and python_version >= '2.7' and python_version != '3.3.*' and python_version != '3.0.*'",
             "version": "==1.5.0"
         },
         "flask": {
@@ -483,7 +504,6 @@
                 "sha256:6e3836e39f4d36ae72840833db137f7b7d35105079aee6ec4a62d9f80d594dd1",
                 "sha256:95eb8364a4708392bae89035f45341871286a333f749c3141c20573d2b3876e1"
             ],
-            "markers": "python_version != '3.2.*' and python_version != '3.1.*' and python_version >= '2.7' and python_version != '3.3.*' and python_version != '3.0.*'",
             "version": "==0.7.1"
         },
         "prompt-toolkit": {
@@ -506,7 +526,6 @@
                 "sha256:3fd59af7435864e1a243790d322d763925431213b6b8529c6ca71081ace3bbf7",
                 "sha256:e31fb2767eb657cbde86c454f02e99cb846d3cd9d61b318525140214fdc0e98e"
             ],
-            "markers": "python_version != '3.2.*' and python_version != '3.1.*' and python_version >= '2.7' and python_version != '3.3.*' and python_version != '3.0.*'",
             "version": "==1.5.4"
         },
         "pyflakes": {
@@ -514,7 +533,6 @@
                 "sha256:9a7662ec724d0120012f6e29d6248ae3727d821bba522a0e6b356eff19126a49",
                 "sha256:f661252913bc1dbe7fcfcbf0af0db3f42ab65aabd1a6ca68fe5d466bace94dae"
             ],
-            "markers": "python_version != '3.2.*' and python_version != '3.1.*' and python_version >= '2.7' and python_version != '3.3.*' and python_version != '3.0.*'",
             "version": "==2.0.0"
         },
         "pygments": {
@@ -543,7 +561,6 @@
             "hashes": [
                 "sha256:be7468edd4d3d83f1e844959fd6e3fd28e77a481440a7118d430130ea31b07a9"
             ],
-            "markers": "python_version != '3.2.*' and python_version != '3.1.*' and python_version >= '2.7' and python_version != '3.3.*' and python_version != '3.0.*'",
             "version": "==1.0"
         },
         "pytest-cov": {

--- a/services/events/project/__init__.py
+++ b/services/events/project/__init__.py
@@ -2,14 +2,14 @@ import os
 
 from flask_cors import CORS
 from flask import Flask
+from flask_caching import Cache
 from flask_sqlalchemy import SQLAlchemy
 from flask_migrate import Migrate
-
 
 # instantiate the extensions
 db = SQLAlchemy()
 migrate = Migrate()
-
+cache = Cache(config={'CACHE_TYPE': 'simple'})
 
 def create_app():
 
@@ -26,6 +26,7 @@ def create_app():
     # set up extensions
     db.init_app(app)
     migrate.init_app(app, db)
+    cache.init_app(app)
 
     # register blueprints
     from project.api.events import events_blueprint

--- a/services/events/project/api/events.py
+++ b/services/events/project/api/events.py
@@ -10,6 +10,7 @@ from project.api.models import Topic
 from project.api.models import Entry
 from project.api.models import Event
 from project import db
+from project import cache
 
 events_blueprint = Blueprint("events", __name__)
 
@@ -148,6 +149,7 @@ def get_single_event(event_id):
 
 
 @events_blueprint.route("/events", methods=["GET"])
+@cache.cached(timeout=1000)
 def get_all_events():
     """Get all events"""
 
@@ -162,7 +164,7 @@ def get_all_events():
             and_(Event.start <= current_time, Event.start >= recent_past)
         )
         .order_by(Event.start)
-        .limit(30)
+        .limit(50)
     )
 
     response_object = {


### PR DESCRIPTION
### What's Changed

Adds `flask-caching` to provide caching of requests for 1000 seconds (approx 15+ minutes)

| Before  | After   | 
|---|---|
| <img width="1680" alt="screen shot 2018-08-21 at 19 46 34" src="https://user-images.githubusercontent.com/1443700/44422931-8888e200-a57c-11e8-80f8-1b970f26556c.png"> | <img width="1680" alt="screen shot 2018-08-21 at 19 47 29" src="https://user-images.githubusercontent.com/1443700/44422957-9cccdf00-a57c-11e8-8f92-be47c6476535.png"> |

### Technical Description

Events do not frequently change so caching the results for 15 minutes can help reduce load times on all subsequent requests. In a local environment, this sees a reduction of 1.21s to 7ms. This doesn't account for network latency but it should help provide a small reduction in load times on the staging/production server.

This PR is a precursor to providing a static file on S3 containing the latest events.