### PR TITLE
Compress Flask application's responses with gzip

### DIFF
--- a/services/events/Pipfile
+++ b/services/events/Pipfile
@@ -15,6 +15,7 @@ flask-bcrypt = "==0.7.1"
 pyjwt = "==1.6.4"
 newrelic = "==4.2.0.100"
 flask-caching = "==1.4.0"
+flask-compress = "*"
 
 [dev-packages]
 black = "==18.6b2"

--- a/services/events/Pipfile.lock
+++ b/services/events/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "781ad99134d14d239f92e3430cc11b170048be4618555c94b2aa5fbb6a27339b"
+            "sha256": "bb39e175b67b5e318dba71851c12dff58e11bfd253b7ad495e35c58620cdcf7d"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -123,6 +123,13 @@
             "hashes": [
                 "sha256:44fe827c6cc519d48fb0945fa05ae3d128af9a98f2a6e71d4702fd512534f227",
                 "sha256:e34f24631ba240e09fe6241e1bf652863e0cff06a1a94598e23be526bc2e4985"
+            ],
+            "index": "pypi",
+            "version": "==1.4.0"
+        },
+        "flask-compress": {
+            "hashes": [
+                "sha256:468693f4ddd11ac6a41bca4eb5f94b071b763256d54136f77957cfee635badb3"
             ],
             "index": "pypi",
             "version": "==1.4.0"

--- a/services/events/project/__init__.py
+++ b/services/events/project/__init__.py
@@ -1,15 +1,18 @@
 import os
 
-from flask_cors import CORS
 from flask import Flask
 from flask_caching import Cache
-from flask_sqlalchemy import SQLAlchemy
+from flask_compress import Compress
+from flask_cors import CORS
 from flask_migrate import Migrate
+from flask_sqlalchemy import SQLAlchemy
 
 # instantiate the extensions
 db = SQLAlchemy()
 migrate = Migrate()
-cache = Cache(config={'CACHE_TYPE': 'simple'})
+cache = Cache(config={"CACHE_TYPE": "simple"})
+compress = Compress()
+
 
 def create_app():
 
@@ -27,6 +30,7 @@ def create_app():
     db.init_app(app)
     migrate.init_app(app, db)
     cache.init_app(app)
+    compress.init_app(app)
 
     # register blueprints
     from project.api.events import events_blueprint


### PR DESCRIPTION
### What's Changed

Flask-Compress will compress the events application's responses with gzip.

This will help reduce the time taken to download responses from the server. At present, downloading responses takes 700ms

<img width="1680" alt="screen shot 2018-08-22 at 21 18 42" src="https://user-images.githubusercontent.com/1443700/44488754-79279880-a651-11e8-9325-38ebae7b9a1f.png">

https://libwilliam.github.io/flask-compress/