### PR TITLE
Declaring google analytics id as a const prior to initialisation

### DIFF
--- a/services/client/src/index.js
+++ b/services/client/src/index.js
@@ -3,6 +3,8 @@ import ReactDOM from "react-dom";
 import ReactGA from "react-ga";
 import App from "./App";
 
-ReactGA.initialize(`${process.env.REACT_APP_GOOGLE_ANALYTICS_ID}`);
+const googleAnalyticId = `${process.env.REACT_APP_GOOGLE_ANALYTICS_ID}`;
+
+ReactGA.initialize(googleAnalyticId);
 
 ReactDOM.render(<App />, document.getElementById("root"));


### PR DESCRIPTION
### What's Changed

Declaring google analytics id as a `const` prior to initialization. This should help debug why the value does not appear to be set during staging/production builds.