### PR TITLE
Adding ingest script for hourly cron builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,7 @@ before_script:
 
 script:
   - bash test.sh $DOCKER_ENV
+  - bash scripts/ingest.sh
 
 after_script:
   - docker-compose -f docker-compose-stage.yml down

--- a/scripts/ingest.sh
+++ b/scripts/ingest.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+if [ "$TRAVIS_BRANCH" == "ingest" ]
+then
+  set -x
+
+  echo "Running staging ingest"
+  bash ./load_data.sh stage
+  echo "Completed staging ingest"
+
+  echo "Running production ingest"
+  bash ./load_data.sh prod
+  echo "Completed production ingest"
+
+  set +x
+fi


### PR DESCRIPTION
### What's Changed

Adds a ingest script to run on an hourly Travis cron build. This helps avoid running scripts locally to update the service.

### Technical description

This is a temporary solution until the data pipeline is created, which will allow the service to remain up to date (without manual intervention). 
* environment configuration has been added to Travis for running staging/production ingest updates.
* Travis will be configured to run the `ingest` branch hourly/daily