### PR TITLE
Add lambda to pull data from eventbrite

### DIFF
--- a/lambdas/README.md
+++ b/lambdas/README.md
@@ -1,5 +1,9 @@
 # Muxer Lambdas
 
+Serverless configured lambdas running on AWS.
+
+---
+
 ## Meetup.com
 
 Lambda used to regularly pull events from Meetup.com. There are helper scripts
@@ -51,5 +55,61 @@ will receive an "Access Denied" error. Instead you may want to comment out the
 `uploadTo` calls whilst in development.
 
 ### `meetupcom:logs`
+
+Pulls the logs from cloudwatch of the last lambda run. Useful for debugging.
+
+---
+
+## Eventbrite
+
+Lambda used to regularly pull events from Eventbrite.com. There are helper scripts
+to aid in deployment and development. Use `npm run <command>` with any of the
+below.
+
+For initial setup, please create a `eventbriteEvents` profile in your
+`~/.aws/credentials` file. Serverless will use this when running the commands
+listed below.
+
+```
+[eventbriteEvents]
+aws_access_key_id = <access-key-id-value>
+aws_secret_access_key = <access-key-value>
+```
+
+You will also need to create a new entry in the AWS Systems Manager Parameter
+store for the Eventbrite API token. Make a secure string with the name
+`eventbriteApiToken` and the value of your Eventbrite API token. Serverless will
+then automatically pull that value into your lambda as an environment variable.
+
+### `eventbrite:deploy`
+
+Deploy (or redeploy) the lambda and all associated infrastructure. Do this
+when setting up for the first time, or whenever the `serverless.yml` file
+changes
+
+### `eventbrite:update`
+
+Update just the handler functionality. Do then whenever you change the
+functionality of the lambda.
+
+### `eventbrite:invoke`
+
+Invoke the lambda on AWS. As this lambda created files in S3, you should see new
+JSON files created of the data pulled from Eventbrite.
+
+### `eventbrite:invoke-local`
+
+Invoke the lambda locally. Use this for development. You will need to pass an
+Eventbrite API token as an environment variable:
+
+```
+EVENTBRITE_API_TOKEN=<token-value> npm run eventbrite:invoke-local
+```
+
+The local lambda will also not have permissions to write the files to S3 and you
+will receive an "Access Denied" error. Instead you may want to comment out the
+`uploadTo` calls whilst in development.
+
+### `eventbrite:logs`
 
 Pulls the logs from cloudwatch of the last lambda run. Useful for debugging.

--- a/lambdas/eventbrite/.gitignore
+++ b/lambdas/eventbrite/.gitignore
@@ -1,0 +1,6 @@
+# package directories
+node_modules
+jspm_packages
+
+# Serverless directories
+.serverless

--- a/lambdas/eventbrite/config.js
+++ b/lambdas/eventbrite/config.js
@@ -1,0 +1,23 @@
+const EVENTBRITE_TECH_CATEGORY = 102;
+
+const convert = params =>
+  Object.entries(params)
+    .map(([key, val]) => `${key}=${val}`)
+    .join("&");
+
+const eventsApi = "https://www.eventbriteapi.com/v3/events/search/";
+const eventsParams = page =>
+  convert({
+    page,
+    sort_by: "date",
+    "location.longitude": -6.762739,
+    "location.latitude": 54.6425126, // Cookstown
+    "location.within": "60mi", // 60 mile radius (all of Northern Ireland)
+    categories: EVENTBRITE_TECH_CATEGORY,
+    token: process.env.EVENTBRITE_API_TOKEN
+  });
+
+module.exports = {
+  bucketName: "eventbrite-events-bucket",
+  getEventsUrl: ({ page }) => `${eventsApi}?${eventsParams(page)}`
+};

--- a/lambdas/eventbrite/handler.js
+++ b/lambdas/eventbrite/handler.js
@@ -1,0 +1,73 @@
+"use strict";
+
+const {
+  createHash,
+  getDateTimePathFor,
+  getFromWeb,
+  setInS3
+} = require("aws-lambda-data-utils");
+const { bucketName, getEventsUrl } = require("./config");
+
+const getErrors = function(eventsPages) {
+  return eventsPages.reduce(function(errors, eventsPage) {
+    if (eventsPage.error) return errors.concat([eventsPage]);
+    return errors;
+  }, []);
+};
+
+const getFromApi = async function() {
+  const initialResponse = await getFromWeb(getEventsUrl({ page: 0 }));
+  const initialData = JSON.parse(initialResponse);
+
+  if (initialData.error) return [initialResponse];
+  const { pagination } = initialData;
+  if (!pagination.has_more_items) return [initialResponse];
+
+  const pagesNumbers = new Array(pagination.page_count - 1)
+    .fill()
+    .map((val, index) => index + 2);
+  const requests = pagesNumbers.map(page => getFromWeb(getEventsUrl({ page })));
+  return Promise.all([initialResponse].concat(requests));
+};
+
+const uploadTo = function(createFilename, data) {
+  const fileContents = JSON.stringify(data);
+  const today = new Date();
+  const hash = createHash(fileContents);
+  const prefix = getDateTimePathFor(today);
+  const filename = createFilename(today, hash);
+  const filePath = `${prefix}/${filename}`;
+
+  return setInS3(prefix, bucketName, filePath, fileContents);
+};
+
+const uploadData = function(eventsPages) {
+  return eventsPages.map(function(eventsPage, index) {
+    return uploadTo(
+      (today, hash) =>
+        `eventbrite-events-page-${index + 1}__${today.valueOf()}__${hash}.json`,
+      eventsPage
+    );
+  });
+};
+
+module.exports.hello = async (event, context, callback) => {
+  try {
+    // Read list of upcoming events
+    const eventsPages = (await getFromApi()).map(JSON.parse);
+
+    const eventsErrors = getErrors(eventsPages);
+    if (eventsErrors.length > 0) {
+      callback(eventsErrors, null);
+      return;
+    }
+
+    // Write captured data to S3
+    const uploads = uploadData(eventsPages);
+    const message = (await Promise.all(uploads)).map(({ key }) => key);
+
+    callback(null, { message, event });
+  } catch (err) {
+    callback(err, null);
+  }
+};

--- a/lambdas/eventbrite/package-lock.json
+++ b/lambdas/eventbrite/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "pull-eventbrite-events",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "aws-lambda-data-utils": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/aws-lambda-data-utils/-/aws-lambda-data-utils-1.0.0.tgz",
+      "integrity": "sha512-jfzEJ7RII1SXAXoKevCS3C9bB0BGU1c8qTVBxqMoOaENVC3cpOSyzdSNdftW7WYHCKlWDt9IBmEcg57LnPL1WA=="
+    }
+  }
+}

--- a/lambdas/eventbrite/package.json
+++ b/lambdas/eventbrite/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "pull-eventbrite-events",
+  "version": "1.0.0",
+  "description": "Pull meetup.com events data",
+  "main": "handler.js",
+  "dependencies": {
+    "aws-lambda-data-utils": "^1.0.0"
+  }
+}

--- a/lambdas/eventbrite/serverless.yml
+++ b/lambdas/eventbrite/serverless.yml
@@ -1,0 +1,28 @@
+service: pull-eventbrite-events
+provider:
+  name: aws
+  runtime: nodejs8.10
+  iamRoleStatements:
+    - Effect: Allow
+      Action:
+        - s3:*
+      Resource:
+        Fn::Join:
+          - ""
+          - - "arn:aws:s3:::"
+            - "Ref" : "EventbriteEventsBucket"
+            - "/*"
+functions:
+  hello:
+    handler: handler.hello
+    events:
+      - schedule: rate(1 hour)
+    environment:
+      TZ: Europe/Belfast
+      EVENTBRITE_API_TOKEN: ${ssm:eventbriteApiToken~true}
+resources:
+  Resources:
+    EventbriteEventsBucket:
+      Type: AWS::S3::Bucket
+      Properties:
+        BucketName: eventbrite-events-bucket

--- a/lambdas/package.json
+++ b/lambdas/package.json
@@ -8,7 +8,12 @@
     "meetupcom:update": "cd meetupcom && serverless deploy function -f hello --aws-profile meetupcomEvents",
     "meetupcom:invoke": "cd meetupcom && serverless invoke -f hello -l --aws-profile meetupcomEvents",
     "meetupcom:invoke-local": "cd meetupcom && serverless invoke local -f hello",
-    "meetupcom:logs": "cd meetupcom && serverless logs -f hello -l --aws-profile meetupcomEvents"
+    "meetupcom:logs": "cd meetupcom && serverless logs -f hello -l --aws-profile meetupcomEvents",
+    "eventbrite:deploy": "cd eventbrite && serverless deploy -v --aws-profile eventbriteEvents",
+    "eventbrite:update": "cd eventbrite && serverless deploy function -f hello --aws-profile eventbriteEvents",
+    "eventbrite:invoke": "cd eventbrite && serverless invoke -f hello -l --aws-profile eventbriteEvents",
+    "eventbrite:invoke-local": "cd eventbrite && serverless invoke local -f hello",
+    "eventbrite:logs": "cd eventbrite && serverless logs -f hello -l --aws-profile eventbriteEvents"
   },
   "dependencies": {
     "serverless": "^1.30.3"


### PR DESCRIPTION
Continuing on #346, this PR adds a lambda to run hourly and pull data from eventbrite.com
Currently this queries eventbriteapi.com for any upcoming events within Northern Ireland (60 mile radius of Cookstown). Rate limiting is 2000 requests per hour - this will make a request per page, which is currently only 1 page (50 results). Each of these pages are then saved to S3.

__Example of data:__ https://gist.github.com/alistairjcbrown/ca9829e5aeaf106c7893a0e4ec604ac5
The above folder file was generated from invoking the lambda and grabbing the file from S3. It would be under a datetime folder structure within the bucket.

![image](https://user-images.githubusercontent.com/635903/44961261-6b51fd00-af06-11e8-8489-95d1e2c280fc.png)
