### PR TITLE
Improve UI for event API errors & empty data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ test-results/
 .coverage
 
 *.pem
+
+.vscode/

--- a/e2e/index.test.js
+++ b/e2e/index.test.js
@@ -10,6 +10,5 @@ test(`should display the page correctly`, async (t) => {
     .navigateTo(TEST_URL)
     .expect(Selector('a').withText('events').exists).ok()
     .expect(Selector('a').withText('videos').exists).ok()
-    .expect(Selector('a').withText('speakers').exists).ok()
     .expect(Selector('a').withText('Make a request').exists).ok()
 });

--- a/services/client/src/components/event/error.js
+++ b/services/client/src/components/event/error.js
@@ -1,0 +1,16 @@
+import React from "react";
+import styles from "./styles/error";
+
+const Error = () => (
+  <React.Fragment>
+    <style jsx>{styles}</style>
+    <div className="content-error">
+      <div className="error-seperator">Oops! Theres a problem</div>
+      <div className="event-error">
+        <p>Sorry! Looks like something went wrong whilst loading the events.</p>
+      </div>
+    </div>
+  </React.Fragment>
+);
+
+export default Error;

--- a/services/client/src/components/event/styles/error.js
+++ b/services/client/src/components/event/styles/error.js
@@ -1,0 +1,21 @@
+import css from "styled-jsx/css";
+
+export default css`
+  .event-error {
+    background-color: #fff;
+    border-bottom: 2px solid #f8fafc;
+    display: flex;
+    padding: 0.5rem;
+    font-weight: 200;
+  }
+
+  .error-seperator {
+    background-color: #5fa8e4;
+    color: #fff;
+    font-size: 0.75rem;
+    padding: 0.5em 0 0.4em 0.5em;
+    position: -webkit-sticky;
+    position: sticky;
+    top: 0;
+  }
+`;

--- a/services/client/src/components/header/navigation.js
+++ b/services/client/src/components/header/navigation.js
@@ -16,7 +16,7 @@ const Navigation = () => (
         videos
       </Link>
     </li>
-    <li>
+    <li style={{ display: "none" }}>
       <Link to="/speaker" className={`navigation-link ${linkStyles.className}`}>
         speakers
       </Link>

--- a/services/client/src/components/no-events/styles.js
+++ b/services/client/src/components/no-events/styles.js
@@ -2,6 +2,7 @@ import css from "styled-jsx/css";
 
 export default css`
   .no-events {
+    background: #fff;
     font-weight: 200;
     padding: 1em;
   }

--- a/services/client/src/pages/events/components/events.js
+++ b/services/client/src/pages/events/components/events.js
@@ -4,6 +4,7 @@ import _ from "lodash";
 import CallToActionBanner from "components/call-to-action-banner";
 import Spinner from "components/spinner/loading";
 import Event from "components/event";
+import Error from "components/event/error";
 import NoEvents from "components/no-events";
 import EventSeparator from "components/event-separator";
 import getBucketsFor from "utils/get-buckets-for";
@@ -27,6 +28,7 @@ class Events extends Component {
         {recentEvents.map(item => (
           <Event key={item.id} className="recent-event" content={item} />
         ))}
+        {recentEvents.length === 0 ? <NoEvents /> : null}
       </div>
     );
   }
@@ -65,7 +67,7 @@ class Events extends Component {
   renderError() {
     const { hasErrors } = this.props;
     if (hasErrors) {
-      return <p>Sorry! There was an error loading the events</p>;
+      return <Error />;
     }
     return null;
   }


### PR DESCRIPTION
### What's Changed

* Hides `speakers` until more data is available
* Displays `No Events` when recent events are empty
* Displays error message at the bottom of the page when there are errors.

Before | After
--- | ---
<img width="1680" alt="screen shot 2018-09-15 at 21 51 01" src="https://user-images.githubusercontent.com/1443700/45590517-d3a2d480-b931-11e8-9305-1aa99ccee6de.png"> | <img width="1680" alt="screen shot 2018-09-15 at 21 41 10" src="https://user-images.githubusercontent.com/1443700/45590518-d8678880-b931-11e8-99c5-5c715aef9aa6.png">

