### PR TITLE
Various design changes; sticky menu and footer, background color, res…

### DIFF
--- a/services/client/src/App.js
+++ b/services/client/src/App.js
@@ -16,7 +16,7 @@ const App = () => (
           margin: 0;
           padding: 0;
           font-family: sans-serif;
-          background-color: #f9f9f7;
+          background-color: rgba(1, 1, 1, 0.05);
         }
       `}</style>
       <style jsx>{`

--- a/services/client/src/components/event-separator/styles.js
+++ b/services/client/src/components/event-separator/styles.js
@@ -7,7 +7,8 @@ export default css`
     font-size: 0.75rem;
     padding: 0.5em 0 0.4em 0.5em;
     position: sticky;
-    top: 0;
+    z-index: 0;
+    top: 3rem;
   }
 
   span {

--- a/services/client/src/components/footer/styles.js
+++ b/services/client/src/components/footer/styles.js
@@ -8,6 +8,9 @@ export default css`
     border-bottom-left-radius: 0.25rem;
     font-size: 0.75rem;
     color: #fff;
+    margin-bottom: 0;
+    position: sticky;
+    bottom: 0;
   }
 
   @media (min-width: 992px) {

--- a/services/client/src/components/header/styles/index.js
+++ b/services/client/src/components/header/styles/index.js
@@ -32,6 +32,9 @@ export default css`
     border-top-right-radius: 0.25rem;
     display: flex;
     padding: 0.5rem;
+    position: sticky;
+    top: 0;
+    z-index: 1;
   }
 
   @media (min-width: 992px) {

--- a/services/client/src/components/header/styles/navigation.js
+++ b/services/client/src/components/header/styles/navigation.js
@@ -8,6 +8,9 @@ export const linkStyles = resolveScopedStyles(
       .navigation-link {
         color: #dae1e7;
       }
+      .navigation-link:hover{
+        color: white;
+      }
     `}</style>
   </scope>
 );
@@ -26,4 +29,5 @@ export default css`
     position: relative;
     margin-right: 1.25rem;
   }
+  
 `;

--- a/services/client/src/components/header/styles/navigation.js
+++ b/services/client/src/components/header/styles/navigation.js
@@ -8,7 +8,7 @@ export const linkStyles = resolveScopedStyles(
       .navigation-link {
         color: #dae1e7;
       }
-      .navigation-link:hover{
+      .navigation-link:hover {
         color: white;
       }
     `}</style>
@@ -29,5 +29,4 @@ export default css`
     position: relative;
     margin-right: 1.25rem;
   }
-  
 `;

--- a/services/client/src/components/spinner/styles/index.js
+++ b/services/client/src/components/spinner/styles/index.js
@@ -5,6 +5,8 @@ export default css`
     margin-left: auto;
     margin-right: auto;
     width: 5em;
+    margin-top: 30%;
+    margin-bottom: 30%;
   }
   .lds-ripple {
     display: inline-block;


### PR DESCRIPTION
Added on on hover styling to the menu
Before: ![muxer_hover_before](https://user-images.githubusercontent.com/32307798/46343149-bf9aea80-c634-11e8-869b-1e711bd3793c.png)
After: ![muxer_link_hover_after](https://user-images.githubusercontent.com/32307798/46343170-cf1a3380-c634-11e8-9741-98088b1e093f.png)

Resized the loading spinner 
Before: ![muxer_spinner_before](https://user-images.githubusercontent.com/32307798/46343069-84002080-c634-11e8-85f5-e32ce5185fa7.png)
After:![muxer_resized_spinner](https://user-images.githubusercontent.com/32307798/46343088-8d898880-c634-11e8-96bc-3e1d61118319.png)

The menu is now sticky

Before: /![muxer_header_before](https://user-images.githubusercontent.com/32307798/46342988-400d1b80-c634-11e8-84de-25357ea7ac16.png)
After: ![muxer_sticky_header](https://user-images.githubusercontent.com/32307798/46343048-734faa80-c634-11e8-8022-cc7d45038806.png)



Also  and increased the z-index so it's not covered by the event separators
Before: ![muzer_sticky_event_sep_before](https://user-images.githubusercontent.com/32307798/46343109-9bd7a480-c634-11e8-8198-c7beff2d59ae.png)

After: ![muxer_sticky_event_sep](https://user-images.githubusercontent.com/32307798/46343118-a72ad000-c634-11e8-9c7e-d1ec430c16ab.png)

It also works in responsive:
![muxer_responsive](https://user-images.githubusercontent.com/32307798/46343131-af830b00-c634-11e8-889e-e4086c5b4e12.png)

The body background-colour has been made light grey to emphasise the content, which can also be seen in the screenshots.
