### PR TITLE
Adding css tweaks for white backgrounds and formatting datetime

### DIFF
--- a/services/client/src/App.js
+++ b/services/client/src/App.js
@@ -18,6 +18,10 @@ const App = () => (
           font-family: sans-serif;
           background-color: rgba(1, 1, 1, 0.05);
         }
+        .page {
+          background: white;
+          height: 100%;
+        }
       `}</style>
       <style jsx>{`
         .container {

--- a/services/client/src/components/event/content.js
+++ b/services/client/src/components/event/content.js
@@ -2,6 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import { formatTitle } from "utils/format";
 import TimeToEvent from "./time-to-event";
+import EventTime from "./event-time";
 import styles from "./styles/content";
 
 const Content = ({ name, start, url, category }) => (
@@ -16,6 +17,9 @@ const Content = ({ name, start, url, category }) => (
       >
         {formatTitle(name)}
       </a>
+    </div>
+    <div className="event-time">
+      <EventTime startTime={start} />
     </div>
     <div className="event-details">
       {category} &nbsp;

--- a/services/client/src/components/event/event-time.js
+++ b/services/client/src/components/event/event-time.js
@@ -3,9 +3,7 @@ import PropTypes from "prop-types";
 import moment from "moment";
 
 const TimeToEvent = ({ startTime }) => {
-  const now = moment();
-  const eventTime = moment.utc(startTime);
-  const duration = moment.duration(eventTime.diff(now));
+  const eventTimeStamp = moment(startTime).format("dddd, Do of MMMM h:mmA");
 
   return (
     <React.Fragment>
@@ -16,9 +14,7 @@ const TimeToEvent = ({ startTime }) => {
           font-weight: 200;
         }
       `}</style>
-      <span className="humanize">
-        ( {duration > 0 ? "next" : "last"} event {duration.humanize(true)} )
-      </span>
+      <span>{eventTimeStamp}</span>
     </React.Fragment>
   );
 };

--- a/services/client/src/components/event/styles/content.js
+++ b/services/client/src/components/event/styles/content.js
@@ -18,6 +18,12 @@ export default css`
     color: #81878c;
   }
 
+  .event-time {
+    font-size: 0.75rem;
+    color: #81878c;
+    margin-bottom: 0.5rem;
+  }
+
   .event-details span {
     padding-right: 0.3rem;
   }

--- a/services/client/src/pages/events/components/events.js
+++ b/services/client/src/pages/events/components/events.js
@@ -53,6 +53,7 @@ class Events extends Component {
 
   renderLoading() {
     const { isLoading } = this.props;
+
     if (isLoading) {
       return <Spinner />;
     }
@@ -74,7 +75,7 @@ class Events extends Component {
 
   render() {
     return (
-      <div>
+      <div className="page">
         <CallToActionBanner />
         {this.renderLoading()}
         {this.renderError()}

--- a/services/client/src/pages/speakers/index.js
+++ b/services/client/src/pages/speakers/index.js
@@ -54,7 +54,7 @@ class Speakers extends Component {
 
   render() {
     return (
-      <div>
+      <div className="page">
         <CallToActionBanner />
         {this.renderRecentSpeakers()}
       </div>

--- a/services/client/src/pages/videos/index.js
+++ b/services/client/src/pages/videos/index.js
@@ -54,7 +54,7 @@ class Videos extends Component {
 
   render() {
     return (
-      <div>
+      <div className="page">
         <CallToActionBanner />
         {this.renderRecentVideos()}
       </div>


### PR DESCRIPTION
### What's Changed

Provides some default background colors for loading page components to display behind the loading spinner. Additionally refactors the time-to-event component into 2 separate components

Provides a white background
<img width="809" alt="screen shot 2018-10-02 at 23 26 46" src="https://user-images.githubusercontent.com/1443700/46380648-091e2080-c69b-11e8-8001-8a516cf29e5e.png">

Moves position of event time
<img width="884" alt="screen shot 2018-10-02 at 23 28 38" src="https://user-images.githubusercontent.com/1443700/46380677-1f2be100-c69b-11e8-9316-7d8add6109e7.png">

