### PR TITLE
Scripts Readme Typo fix

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -28,9 +28,9 @@ You can request an API key for both services using the following links:
 Lastly, you will need to provide the endpoint which will update your local service.
 
 ```
-EVENTS_ENDPOINT=http:localhost/events
-VIDEOS_ENDPOINT=http:localhost/videos
-SPEAKERS_ENDPOINT=http:localhost/speakers
+EVENTS_ENDPOINT=http://localhost/events
+VIDEOS_ENDPOINT=http://localhost/videos
+SPEAKERS_ENDPOINT=http://localhost/speakers
 ```
 
 Ensure all database migrations have been applied to a running database, and that the optional seed_db command has been run for the users service. If you request data from http:localhost/events and do not see a Flask error page, then you are good to proceed.


### PR DESCRIPTION
### Title
Scripts Readme typo fix

### What's Changed
the url environment variables were missing a double slash after `http:`. Added those

