### PR TITLE
Adding link to API docs in the Footer component

### DIFF
--- a/services/client/src/components/footer/index.js
+++ b/services/client/src/components/footer/index.js
@@ -6,7 +6,12 @@ const Footer = () => (
   <div className="footer">
     <style jsx>{styles}</style>
     <div>
-      &copy; 2018 | Built by
+      &copy; 2018 |
+      <a href={`${process.env.REACT_APP_EVENTS_SERVICE_URL}/swagger`}>
+        <FontAwesome name="book" />
+        {" API"}
+      </a>
+      | Built by
       <a href="https://github.com/apoclyps/my-dev-space/graphs/contributors">
         <FontAwesome name="github" />
         {" open source contributions"}

--- a/services/swagger/swagger.json
+++ b/services/swagger/swagger.json
@@ -1,8 +1,8 @@
 {
   "info": {
     "version": "0.0.1",
-    "description": "Swagger spec for documenting the users service",
-    "title": "Users Service"
+    "description": "A developer community for everyone with an interest in Technology & Meetups. You can find out more about Swagger at http://swagger.io.",
+    "title": "Muxer API Service"
   },
   "paths": {
     "/auth/logout": {
@@ -291,7 +291,7 @@
     }
   },
   "servers": [{
-    "url": "http://my-dev-space-production-alb-453010484.us-east-1.elb.amazonaws.com"
+    "url": "https://muxer.co.uk"
   }],
   "components": {
     "securitySchemes": {


### PR DESCRIPTION
### What's Changed

Add links to `Footer` component for the Swagger API Docs.

| Before | After |
|--- | --- |
| <img width="682" alt="screen shot 2018-10-06 at 21 02 07" src="https://user-images.githubusercontent.com/1443700/46575330-6243c800-c9ab-11e8-8ef1-c92c51401aa3.png"> | <img width="669" alt="screen shot 2018-10-06 at 21 01 27" src="https://user-images.githubusercontent.com/1443700/46575331-6b349980-c9ab-11e8-877e-e285c3a49358.png"> |

### Technical Description

Links to environment in which the service is running e.g. local, staging, production.








