### PR TITLE
Add lambda to pull data from Farset Labs calendar

### DIFF
--- a/lambdas/README.md
+++ b/lambdas/README.md
@@ -113,3 +113,52 @@ will receive an "Access Denied" error. Instead you may want to comment out the
 ### `eventbrite:logs`
 
 Pulls the logs from cloudwatch of the last lambda run. Useful for debugging.
+
+---
+
+## Farset Labs Calendar
+
+Lambda used to regularly pull events from the Farset Labs calendar. There are
+helper scripts to aid in deployment and development. Use `npm run <command>`
+with any of the below.
+
+For initial setup, please create a `farsetlabsEvents` profile in your
+`~/.aws/credentials` file. Serverless will use this when running the commands
+listed below.
+
+```
+[farsetlabsEvents]
+aws_access_key_id = <access-key-id-value>
+aws_secret_access_key = <access-key-value>
+```
+
+The Farset Labs calendar is public. You will not need to set any API tokens to
+run this lambda.
+
+### `farsetlabs:deploy`
+
+Deploy (or redeploy) the lambda and all associated infrastructure. Do this
+when setting up for the first time, or whenever the `serverless.yml` file
+changes
+
+### `farsetlabs:update`
+
+Update just the handler functionality. Do then whenever you change the
+functionality of the lambda.
+
+### `farsetlabs:invoke`
+
+Invoke the lambda on AWS. As this lambda created files in S3, you should see new
+ICS files created of the data pulled from the Farset Labs calendar.
+
+### `farsetlabs:invoke-local`
+
+Invoke the lambda locally. Use this for development.
+
+The local lambda will not have permissions to write the files to S3 and you
+will receive an "Access Denied" error. Instead you may want to comment out the
+`uploadTo` calls whilst in development.
+
+### `farsetlabs:logs`
+
+Pulls the logs from cloudwatch of the last lambda run. Useful for debugging.

--- a/lambdas/eventbrite/package.json
+++ b/lambdas/eventbrite/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pull-eventbrite-events",
   "version": "1.0.0",
-  "description": "Pull meetup.com events data",
+  "description": "Pull eventbrite.com events data",
   "main": "handler.js",
   "dependencies": {
     "aws-lambda-data-utils": "^1.0.0"

--- a/lambdas/farsetlabs/.gitignore
+++ b/lambdas/farsetlabs/.gitignore
@@ -1,0 +1,6 @@
+# package directories
+node_modules
+jspm_packages
+
+# Serverless directories
+.serverless

--- a/lambdas/farsetlabs/config.js
+++ b/lambdas/farsetlabs/config.js
@@ -1,0 +1,6 @@
+const eventsApi = "https://calendar.google.com/calendar/ical/farsetlabs.org.uk_srmqnkn373auq51u00s2nijrq8%40group.calendar.google.com/public/basic.ics";
+
+module.exports = {
+  bucketName: "farsetlabs-events-bucket",
+  getEventsUrl: () => eventsApi
+};

--- a/lambdas/farsetlabs/handler.js
+++ b/lambdas/farsetlabs/handler.js
@@ -1,0 +1,53 @@
+"use strict";
+
+const icalendar = require('icalendar');
+const {
+  createHash,
+  getDateTimePathFor,
+  getFromWeb,
+  setInS3
+} = require("aws-lambda-data-utils");
+const { bucketName, getEventsUrl } = require("./config");
+
+const getFromApi = async function() {
+  const initialResponse = await getFromWeb(getEventsUrl());
+  const calendar = icalendar.parse_calendar(initialResponse);
+
+  if (calendar.events().length < 1) {
+    throw new Error("No events found");
+  }
+
+  return initialResponse;
+}
+
+const uploadTo = function(createFilename, fileContents) {
+  const today = new Date();
+  const hash = createHash(fileContents);
+  const prefix = getDateTimePathFor(today);
+  const filename = createFilename(today, hash);
+  const filePath = `${prefix}/${filename}`;
+
+  return setInS3(prefix, bucketName, filePath, fileContents);
+};
+
+const uploadData = function(calendarData) {
+    return uploadTo(
+      (today, hash) =>
+        `farset-labs-calendar__${today.valueOf()}__${hash}.ics`,
+        calendarData
+    );
+};
+
+module.exports.hello = async (event, context, callback) => {
+  try {
+    // Read list of upcoming events
+    const calendarData = await getFromApi();
+
+    // Write captured data to S3
+    const message = (await uploadData(calendarData)).key;
+
+    callback(null, { message, event });
+  } catch (err) {
+    callback(err, null);
+  }
+};

--- a/lambdas/farsetlabs/package-lock.json
+++ b/lambdas/farsetlabs/package-lock.json
@@ -1,0 +1,18 @@
+{
+  "name": "pull-farsetlabs-events",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "aws-lambda-data-utils": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/aws-lambda-data-utils/-/aws-lambda-data-utils-1.0.0.tgz",
+      "integrity": "sha512-jfzEJ7RII1SXAXoKevCS3C9bB0BGU1c8qTVBxqMoOaENVC3cpOSyzdSNdftW7WYHCKlWDt9IBmEcg57LnPL1WA=="
+    },
+    "icalendar": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/icalendar/-/icalendar-0.7.1.tgz",
+      "integrity": "sha1-0NNIZ5X48cXPT4yvrAgbS056Mq4="
+    }
+  }
+}

--- a/lambdas/farsetlabs/package.json
+++ b/lambdas/farsetlabs/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "pull-farsetlabs-events",
+  "version": "1.0.0",
+  "description": "Pull Farset Labs events data",
+  "main": "handler.js",
+  "dependencies": {
+    "aws-lambda-data-utils": "^1.0.0",
+    "icalendar": "^0.7.1"
+  }
+}

--- a/lambdas/farsetlabs/serverless.yml
+++ b/lambdas/farsetlabs/serverless.yml
@@ -1,0 +1,27 @@
+service: pull-farsetlabs-events
+provider:
+  name: aws
+  runtime: nodejs8.10
+  iamRoleStatements:
+    - Effect: Allow
+      Action:
+        - s3:*
+      Resource:
+        Fn::Join:
+          - ""
+          - - "arn:aws:s3:::"
+            - "Ref" : "FarsetlabsEventsBucket"
+            - "/*"
+functions:
+  hello:
+    handler: handler.hello
+    events:
+      - schedule: rate(1 hour)
+    environment:
+      TZ: Europe/Belfast
+resources:
+  Resources:
+    FarsetlabsEventsBucket:
+      Type: AWS::S3::Bucket
+      Properties:
+        BucketName: farsetlabs-events-bucket

--- a/lambdas/package.json
+++ b/lambdas/package.json
@@ -13,7 +13,12 @@
     "eventbrite:update": "cd eventbrite && serverless deploy function -f hello --aws-profile eventbriteEvents",
     "eventbrite:invoke": "cd eventbrite && serverless invoke -f hello -l --aws-profile eventbriteEvents",
     "eventbrite:invoke-local": "cd eventbrite && serverless invoke local -f hello",
-    "eventbrite:logs": "cd eventbrite && serverless logs -f hello -l --aws-profile eventbriteEvents"
+    "eventbrite:logs": "cd eventbrite && serverless logs -f hello -l --aws-profile eventbriteEvents",
+    "farsetlabs:deploy": "cd farsetlabs && serverless deploy -v --aws-profile farsetlabsEvents",
+    "farsetlabs:update": "cd farsetlabs && serverless deploy function -f hello --aws-profile farsetlabsEvents",
+    "farsetlabs:invoke": "cd farsetlabs && serverless invoke -f hello -l --aws-profile farsetlabsEvents",
+    "farsetlabs:invoke-local": "cd farsetlabs && serverless invoke local -f hello",
+    "farsetlabs:logs": "cd farsetlabs && serverless logs -f hello -l --aws-profile farsetlabsEvents"
   },
   "dependencies": {
     "serverless": "^1.30.3"


### PR DESCRIPTION
Continuing on from previous lambda work, this PR adds a lambda to run hourly and pull data from the Farset Labs calendar.
Currently this queries the Google Calendar iCalendar endpoint for all Farset Labs events. The ICS response is then saved to S3.

__Example of data:__ https://gist.github.com/alistairjcbrown/29c3ad46b65a497bb7124856ca720aa4
The above file was generated from invoking the lambda and grabbing the file from S3. It would be under a datetime folder structure within the bucket.

![image](https://user-images.githubusercontent.com/635903/46575542-d03dbe80-c9ae-11e8-86ec-6d1a36489685.png)
