### PR TITLE
Update producer lambda requests for additional data

### DIFF
--- a/lambdas/eventbrite/config.js
+++ b/lambdas/eventbrite/config.js
@@ -13,6 +13,7 @@ const eventsParams = page =>
     "location.longitude": -6.762739,
     "location.latitude": 54.6425126, // Cookstown
     "location.within": "60mi", // 60 mile radius (all of Northern Ireland)
+    expand: "logo,venue,organizer,format,category,subcategory,bookmark_info,refund_policy,ticket_availability",
     categories: EVENTBRITE_TECH_CATEGORY,
     token: process.env.EVENTBRITE_API_TOKEN
   });

--- a/lambdas/meetupcom/config.js
+++ b/lambdas/meetupcom/config.js
@@ -12,6 +12,7 @@ const groupsParams = convert({
   lon: -6.762739,
   lat: 54.6425126, // Cookstown
   radius: 60, // 60 mile radius (all of Northern Ireland)
+  fields: "approved,best_topics,past_event_count,plain_text_description,topics",
   upcoming_events: true,
   fallback_suggestions: false,
   category: MEETUPCOM_TECH_CATEGORY,


### PR DESCRIPTION
### What's Changed

While reviewing the output of each producer lambda, I noticed that we're not getting all of the data we want from each - for these APIs, some data is optional / need expanded. This updates the Eventbrite and Meetup.com API calls to include optional data / expand truncated data.