### PR TITLE
Update to using Farset Labs Calendar JSON endpoint

### DIFF
--- a/lambdas/README.md
+++ b/lambdas/README.md
@@ -154,8 +154,11 @@ changes
 This lambda pulls data from the Farset Labs calendar iCalendar endpoint and
 saves it to S3.
 
-The Farset Labs calendar is public. You will not need to set any API tokens to
-run this lambda.
+You will need to create a new entry in the AWS Systems Manager Parameter store
+for the Google Calendar API token. Make a secure string with the name
+`googleCalendarApiToken` and the value of your Eventbrite API token. Serverless
+will then automatically pull that value into your lambda as an environment
+variable.
 
 #### `farsetlabs:producer:update`
 
@@ -169,7 +172,12 @@ ICS files created with the data pulled from the Farset Labs calendar.
 
 #### `farsetlabs:producer:invoke-local`
 
-Invoke the lambda locally. Use this for development.
+Invoke the lambda locally. Use this for development. You will need to pass an
+Google Calendar API token as an environment variable:
+
+```
+GOOGLE_CALENDAR_API_TOKEN=<token-value> npm run farsetlabs:producer:invoke-local
+```
 
 The local lambda will not have permissions to write the files to S3 and you
 will receive an "Access Denied" error. Instead you may want to comment out the

--- a/lambdas/farsetlabs/config.js
+++ b/lambdas/farsetlabs/config.js
@@ -1,6 +1,24 @@
-const eventsApi = "https://calendar.google.com/calendar/ical/farsetlabs.org.uk_srmqnkn373auq51u00s2nijrq8%40group.calendar.google.com/public/basic.ics";
+const CALENDAR_ID = 'farsetlabs.org.uk_srmqnkn373auq51u00s2nijrq8%40group.calendar.google.com'
+
+const addYear = (date) => new Date(date.setFullYear(date.getFullYear() + 1));
+
+const convert = params =>
+  Object.entries(params)
+    .map(([key, val]) => `${key}=${val}`)
+    .join("&");
+
+const eventsApi = `https://www.googleapis.com/calendar/v3/calendars/${CALENDAR_ID}/events`;
+const eventsParams = () =>
+  convert({
+    maxResults: 2500,
+    singleEvents: true,
+    orderBy: 'startTime',
+    timeMin: new Date().toISOString(),
+    timeMax: addYear(new Date()).toISOString(),
+    key: process.env.GOOGLE_CALENDAR_API_TOKEN
+  });
 
 module.exports = {
   bucketName: "farsetlabs-events-bucket",
-  getEventsUrl: () => eventsApi
+  getEventsUrl: () => `${eventsApi}?${eventsParams()}`
 };

--- a/lambdas/farsetlabs/handlers/transformer.js
+++ b/lambdas/farsetlabs/handlers/transformer.js
@@ -1,6 +1,5 @@
 "use strict";
 
-const icalendar = require('icalendar');
 const { getFromS3 } = require("aws-lambda-data-utils");
 
 module.exports.transform = async (event, context, callback) => {
@@ -11,11 +10,11 @@ module.exports.transform = async (event, context, callback) => {
       s3: { bucket, object: file }
     }) {
       const calendarFile = await getFromS3(bucket.name, file.key);
-      const calendar = icalendar.parse_calendar(calendarFile.Body.toString('utf-8'));
+      const calendar = JSON.parse(calendarFile.Body.toString('utf-8'));
 
       // TODO: Update this to convert to standardised event format
       //       Don't foget to remove events in the past
-      return calendar.events().length;
+      return calendar.items.length;
     }));
 
     // TODO: Update this to output standardised event to publish bucket

--- a/lambdas/farsetlabs/package-lock.json
+++ b/lambdas/farsetlabs/package-lock.json
@@ -8,11 +8,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/aws-lambda-data-utils/-/aws-lambda-data-utils-1.0.0.tgz",
       "integrity": "sha512-jfzEJ7RII1SXAXoKevCS3C9bB0BGU1c8qTVBxqMoOaENVC3cpOSyzdSNdftW7WYHCKlWDt9IBmEcg57LnPL1WA=="
-    },
-    "icalendar": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/icalendar/-/icalendar-0.7.1.tgz",
-      "integrity": "sha1-0NNIZ5X48cXPT4yvrAgbS056Mq4="
     }
   }
 }

--- a/lambdas/farsetlabs/package.json
+++ b/lambdas/farsetlabs/package.json
@@ -2,9 +2,7 @@
   "name": "pull-farsetlabs-events",
   "version": "1.0.0",
   "description": "Pull Farset Labs events data",
-  "main": "handler.js",
   "dependencies": {
-    "aws-lambda-data-utils": "^1.0.0",
-    "icalendar": "^0.7.1"
+    "aws-lambda-data-utils": "^1.0.0"
   }
 }

--- a/lambdas/farsetlabs/serverless.yml
+++ b/lambdas/farsetlabs/serverless.yml
@@ -24,6 +24,7 @@ functions:
       - schedule: rate(1 hour)
     environment:
       TZ: Europe/Belfast
+      GOOGLE_CALENDAR_API_TOKEN: ${ssm:googleCalendarApiToken~true}
   transform:
     handler: handlers/transformer.transform
     environment:


### PR DESCRIPTION
### What's Changed

Following the same pattern as the existing Farset Labs Calendar script used to populate Muxer, this PR updates the lambda to make use of the Google Calendar API to provide a JSON endpoint for the calendar, instead of having to parse iCalendar. Readme, producer and initial transformer implementation have all been updated; a Google API key is now required for the producer.

Example payload now saved in S3: https://gist.github.com/alistairjcbrown/e4c0cf368d6930d73c436e7aaa64cb77

A single event will look like:
```json
{
      "kind": "calendar#event",
      "etag": "\"3053797656240000\"",
      "id": "4b471u35laf5kgeegsjjku3lu8_20181018T180000Z",
      "status": "confirmed",
      "htmlLink": "https://www.google.com/calendar/event?eid=NGI0NzF1MzVsYWY1a2dlZWdzamprdTNsdThfMjAxODEwMThUMTgwMDAwWiBmYXJzZXRsYWJzLm9yZy51a19zcm1xbmtuMzczYXVxNTF1MDBzMm5panJxOEBn",
      "created": "2018-05-21T10:21:12.000Z",
      "updated": "2018-05-21T10:33:48.120Z",
      "summary": "Code Co-op NI",
      "description": "https://www.meetup.com/CodeCoop-NI",
      "location": "Event Space, Farset Labs",
      "creator": {
        "email": "glenn.davidson@farsetlabs.org.uk"
      },
      "organizer": {
        "email": "farsetlabs.org.uk_srmqnkn373auq51u00s2nijrq8@group.calendar.google.com",
        "displayName": "Farset Labs Events",
        "self": true
      },
      "start": {
        "dateTime": "2018-10-18T19:00:00+01:00",
        "timeZone": "Europe/London"
      },
      "end": {
        "dateTime": "2018-10-18T21:00:00+01:00",
        "timeZone": "Europe/London"
      },
      "recurringEventId": "4b471u35laf5kgeegsjjku3lu8_R20180621T180000",
      "originalStartTime": {
        "dateTime": "2018-10-18T19:00:00+01:00",
        "timeZone": "Europe/London"
      },
      "iCalUID": "4b471u35laf5kgeegsjjku3lu8_R20180621T180000@google.com",
      "sequence": 1
    }
```