### PR TITLE
Implement Farset Labs events transformer

### DIFF
--- a/lambdas/farsetlabs/config.js
+++ b/lambdas/farsetlabs/config.js
@@ -1,11 +1,6 @@
+const { addYear, convert } = require("./utils");
+
 const CALENDAR_ID = 'farsetlabs.org.uk_srmqnkn373auq51u00s2nijrq8%40group.calendar.google.com'
-
-const addYear = (date) => new Date(date.setFullYear(date.getFullYear() + 1));
-
-const convert = params =>
-  Object.entries(params)
-    .map(([key, val]) => `${key}=${val}`)
-    .join("&");
 
 const eventsApi = `https://www.googleapis.com/calendar/v3/calendars/${CALENDAR_ID}/events`;
 const eventsParams = () =>
@@ -19,6 +14,9 @@ const eventsParams = () =>
   });
 
 module.exports = {
-  bucketName: "farsetlabs-events-bucket",
+  buckets: () => ({
+    producerBucket: "muxer-produced-events-farsetlabs",
+    eventsBucket: "muxer-transformed-events"
+  }),
   getEventsUrl: () => `${eventsApi}?${eventsParams()}`
 };

--- a/lambdas/farsetlabs/handlers/producer.js
+++ b/lambdas/farsetlabs/handlers/producer.js
@@ -1,41 +1,16 @@
 "use strict";
 
-const {
-  createHash,
-  getDateTimePathFor,
-  getFromWeb,
-  setInS3
-} = require("aws-lambda-data-utils");
-const { bucketName, getEventsUrl } = require("../config");
-
-const uploadTo = function(createFilename, data) {
-  const fileContents = JSON.stringify(data);
-  const today = new Date();
-  const hash = createHash(fileContents);
-  const prefix = getDateTimePathFor(today);
-  const filename = createFilename(today, hash);
-  const filePath = `${prefix}/${filename}`;
-
-  return setInS3(prefix, bucketName, filePath, fileContents);
-};
-
-const uploadData = function(calendarData) {
-    return uploadTo(
-      (today, hash) =>
-        `farset-labs-calendar__${today.valueOf()}__${hash}.json`,
-        calendarData
-    );
-};
+const { getFromWeb } = require("aws-lambda-data-utils");
+const { buckets, getEventsUrl } = require("../config");
+const { uploadData } = require("../utils");
 
 module.exports.produce = async (event, context, callback) => {
   try {
-    // Read list of upcoming events
     const calendarData = JSON.parse(await getFromWeb(getEventsUrl()));
+    const { producerBucket } = buckets();
+    const filePath = (await uploadData(producerBucket, calendarData)).key;
 
-    // Write captured data to S3
-    const message = (await uploadData(calendarData)).key;
-
-    callback(null, { message });
+    callback(null, { message: filePath });
   } catch (err) {
     callback(err, null);
   }

--- a/lambdas/farsetlabs/handlers/schemas/event-schema.json
+++ b/lambdas/farsetlabs/handlers/schemas/event-schema.json
@@ -1,0 +1,261 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "time": {
+      "type": "object",
+      "required": [
+        "utc",
+        "timezone"
+      ],
+      "properties": {
+        "utc": {
+          "type": "string",
+          "format": "date-time",
+          "title": "ISO 8601 to second precision in UTC",
+          "pattern": "(:?\\d{4})-(:?\\d{2})-(:?\\d{2})T(:?\\d{2})\\:(:?\\d{2})\\:(:?\\d{2}).(:?\\d{3})Z",
+          "examples": ["2018-10-20T18:00:00.000Z"]
+        },
+        "timezone": {
+          "type": "string",
+          "title": "Timezone in TZ value",
+          "pattern": "\\w+\\/[\\w\\/]+",
+          "examples": ["Europe/Belfast"]
+        }
+      }
+    },
+    "image-set": {
+      "type": "object",
+      "required": [
+        "regular"
+      ],
+      "properties": {
+        "high": {
+          "type": "string",
+          "format": "uri",
+          "title": "URL to high resolution image"
+        },
+        "regular": {
+          "type": "string",
+          "format": "uri",
+          "title": "URL to regular resolution image"
+        },
+        "thumnail": {
+          "type": "string",
+          "format": "uri",
+          "title": "URL to thumbnail image"
+        }
+      }
+    }
+  },
+  "type": "object",
+  "required": [
+    "name",
+    "times",
+    "venue",
+    "created_at",
+    "last_updated",
+    "source_data"
+  ],
+  "properties": {
+    "name": {
+      "type": "string",
+      "title": "Name of event",
+      "examples": ["Code Co-Op Challenge"]
+    },
+    "description": {
+      "type": "string",
+      "title": "Description of event",
+      "examples": ["Try your hand at this month's coding challenge and learn how your peers tackle the same task."]
+    },
+    "url": {
+      "type": "string",
+      "title": "URL to source webpage for event",
+      "examples": ["https://www.meetup.com/CodeCoop-NI/events/ggxkhqyxpbcb/"]
+    },
+    "times": {
+      "type": "object",
+      "title": "Timing information for the event",
+      "required": [
+        "start",
+        "end",
+        "duration"
+      ],
+      "properties": {
+        "start": {
+          "$ref": "#/definitions/time"
+        },
+        "end": {
+          "$ref": "#/definitions/time"
+        },
+        "duration": {
+          "type": "integer",
+          "title": "Number of milliseconds between start and end times",
+          "examples": [14400000]
+        }
+      }
+    },
+    "logo": {
+      "$ref": "#/definitions/image-set"
+    },
+    "topics": {
+      "type": "array",
+      "title": "Topics describing the event",
+      "items": {
+        "type": "string",
+        "examples": ["Science & Technology"]
+      }
+    },
+    "venue": {
+      "type": "object",
+      "required": [
+        "name",
+        "address",
+        "city",
+        "country",
+        "latitude",
+        "longitude"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name of venue",
+          "examples": ["Farset Labs"]
+        },
+        "address": {
+          "type": "string",
+          "title": "Address of venue",
+          "examples": ["Weavers Court, Linfield Road, BT12 5GH"]
+        },
+        "city": {
+          "type": "string",
+          "title": "City the venue is in",
+          "examples": ["Belfast"]
+        },
+        "country": {
+          "type": "string",
+          "title": "Country the venue is in, must be ISO 3166-1 alpha-2 upper cased two-letter country code",
+          "pattern": "[A-Z]{2}",
+          "examples": ["GB"]
+        },
+        "latitude": {
+          "type": "string",
+          "title": "Latitude of venue location, no precision requirement",
+          "examples": ["54.592826"]
+        },
+        "longitude": {
+          "type": "string",
+          "title": "Longitude of venue location, no precision requirement",
+          "examples": ["-5.940666"]
+        }
+      }
+    },
+    "organiser": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name of organiser or organising group",
+          "examples": ["Code Co-Op"]
+        },
+        "logo": {
+          "$ref": "#/definitions/image-set"
+        }
+      }
+    },
+    "attendee_numbers": {
+      "type": "object",
+      "required": [
+        "capacity",
+        "responses",
+        "waitlist"
+      ],
+      "properties": {
+        "capacity": {
+          "type": "integer",
+          "title": "The maximum number of attendees",
+          "examples": [50]
+        },
+        "responses": {
+          "type": "integer",
+          "title": "The number of people who are going / have indicated they are going",
+          "examples": [38]
+        },
+        "waitlist": {
+          "type": "integer",
+          "title": "The number of people who are on the wait list (when at capacity)",
+          "examples": [0]
+        }
+      }
+    },
+    "charge": {
+      "type": "object",
+      "required": [
+        "is_free"
+      ],
+      "properties": {
+        "is_free": {
+          "type": "boolean",
+          "title": "Whether the event is free to attend",
+          "examples": [false]
+        },
+        "cost": {
+          "type": "object",
+          "required": [
+            "currency",
+            "value"
+          ],
+          "properties": {
+            "currency": {
+              "type": "string",
+              "title": "Currency of the cost, must be ISO 4217 three-letter currency code",
+              "pattern": "[A-Z]{2}",
+              "examples": ["GBP"]
+            },
+            "value": {
+              "type": "integer",
+              "title": "Number representing the value of the cost in the lowest denomination (eg. pence if in GBP)",
+              "examples": [1200]
+            }
+          }
+        }
+      }
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time",
+      "title": "ISO 8601 to second precision in UTC",
+      "pattern": "(:?\\d{4})-(:?\\d{2})-(:?\\d{2})T(:?\\d{2})\\:(:?\\d{2})\\:(:?\\d{2}).(:?\\d{3})Z",
+      "examples": ["2018-06-20T09:26:59Z"]
+    },
+    "last_updated": {
+      "type": "string",
+      "format": "date-time",
+      "title": "ISO 8601 to second precision in UTC",
+      "pattern": "(:?\\d{4})-(:?\\d{2})-(:?\\d{2})T(:?\\d{2})\\:(:?\\d{2})\\:(:?\\d{2}).(:?\\d{3})Z",
+      "examples": ["2018-10-07T14:51:21Z"]
+    },
+    "source_data": {
+      "type": "object",
+      "required": [
+        "name",
+        "id"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name of the source, eg. farsetlabs-calendar, meetupcom, eventbrite, etc.",
+          "enum": ["meetupcom", "eventbrite", "farsetlabs-calendar"],
+          "examples": ["farsetlabs-calendar"]
+        },
+        "id": {
+          "type": "string",
+          "title": "ID of the event from the source",
+          "examples": ["316kag8mfr56qt58k3guo4ejsr@google.com"]
+        }
+      }
+    }
+  }
+}

--- a/lambdas/farsetlabs/handlers/transformer.js
+++ b/lambdas/farsetlabs/handlers/transformer.js
@@ -1,26 +1,81 @@
 "use strict";
 
 const { getFromS3 } = require("aws-lambda-data-utils");
+const { validate } = require("jsonschema");
+const eventSchema = require("./schemas/event-schema");
+const { buckets } = require("../config");
+const { uploadData } = require("../utils");
+
+const transformEvent = function (defaults, {
+  id, summary, description, start, end, created, updated
+}) {
+  const startDate = new Date(start.dateTime);
+  const endDate = new Date(end.dateTime);
+
+  return {
+    name: summary,
+    description,
+    url: "https://www.farsetlabs.org.uk/events/#upcoming-events",
+    times: {
+      start: {
+        utc: startDate.toISOString(),
+        timezone: start.timeZone || defaults.timeZone
+      },
+      end: {
+        utc: endDate.toISOString(),
+        timezone: end.timeZone || defaults.timeZone
+      },
+      duration: endDate - startDate
+    },
+    topics: [],
+    venue: {
+      name: "Farset Labs",
+      latitude: "54.592826",
+      longitude: "-5.940666",
+      address: "Weavers Court, Linfield Road, BT12 5GH",
+      city: "Belfast",
+      country: "GB"
+    },
+    created_at: new Date(created).toISOString(),
+    last_updated: new Date(updated).toISOString(),
+    source_data: {
+      name: "farsetlabs-calendar",
+      id
+    }
+  };
+};
+
+const isValidEvent = (event) => validate(event, eventSchema).errors.length === 0;
 
 module.exports.transform = async (event, context, callback) => {
   try {
     const records = event.Records;
 
-    const eventsCount = await Promise.all(await records.map(async function ({
+    const transformedCalendars = await Promise.all(await records.map(async function ({
       s3: { bucket, object: file }
     }) {
-      const calendarFile = await getFromS3(bucket.name, file.key);
-      const calendar = JSON.parse(calendarFile.Body.toString('utf-8'));
+      const calendarData = await getFromS3(bucket.name, file.key);
+      const calendar = JSON.parse(calendarData.Body.toString());
 
-      // TODO: Update this to convert to standardised event format
-      //       Don't foget to remove events in the past
-      return calendar.items.length;
+      const transformedEvents = calendar.items.map((event) => (
+        transformEvent({ timeZone: calendar.timeZone }, event)
+      ));
+
+      const validEvents = transformedEvents.filter(isValidEvent)
+
+      if (validEvents.length !== transformedEvents.length) {
+        console.log('WARNING: some events generated were not valid!')
+      }
+
+      return validEvents;
     }));
 
-    // TODO: Update this to output standardised event to publish bucket
-    console.log("eventsCount", JSON.stringify(eventsCount));
+    const { eventsBucket } = buckets();
+    const filePaths = await Promise.all(await transformedCalendars.map(async function (transformedCalendar) {
+      return (await uploadData(eventsBucket, transformedCalendar)).key;
+    }));
 
-    callback(null, { message: eventsCount });
+    callback(null, { message: filePaths });
   } catch (err) {
     callback(err, null);
   }

--- a/lambdas/farsetlabs/package-lock.json
+++ b/lambdas/farsetlabs/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "pull-farsetlabs-events",
+  "name": "muxer-pull-events-farsetlabs",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -8,6 +8,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/aws-lambda-data-utils/-/aws-lambda-data-utils-1.0.0.tgz",
       "integrity": "sha512-jfzEJ7RII1SXAXoKevCS3C9bB0BGU1c8qTVBxqMoOaENVC3cpOSyzdSNdftW7WYHCKlWDt9IBmEcg57LnPL1WA=="
+    },
+    "jsonschema": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.4.tgz",
+      "integrity": "sha512-lz1nOH69GbsVHeVgEdvyavc/33oymY1AZwtePMiMj4HZPMbP5OIKK3zT9INMWjwua/V4Z4yq7wSlBbSG+g4AEw=="
     }
   }
 }

--- a/lambdas/farsetlabs/package.json
+++ b/lambdas/farsetlabs/package.json
@@ -1,8 +1,9 @@
 {
-  "name": "pull-farsetlabs-events",
+  "name": "muxer-pull-events-farsetlabs",
   "version": "1.0.0",
   "description": "Pull Farset Labs events data",
   "dependencies": {
-    "aws-lambda-data-utils": "^1.0.0"
+    "aws-lambda-data-utils": "^1.0.0",
+    "jsonschema": "^1.2.4"
   }
 }

--- a/lambdas/farsetlabs/serverless.yml
+++ b/lambdas/farsetlabs/serverless.yml
@@ -1,7 +1,6 @@
-service: muxer-pull-farsetlabs-events
+service: ${file(./package.json):name}
 
-custom:
-  bucketName: "farsetlabs-events-bucket"
+custom: ${file(./config.js):buckets}
 
 provider:
   name: aws
@@ -14,7 +13,16 @@ provider:
         Fn::Join:
           - ""
           - - "arn:aws:s3:::"
-            - ${self:custom.bucketName}
+            - ${self:custom.producerBucket}
+            - "/*"
+    - Effect: Allow
+      Action:
+        - "s3:PutObject"
+      Resource:
+        Fn::Join:
+          - ""
+          - - "arn:aws:s3:::"
+            - ${self:custom.eventsBucket}
             - "/*"
 
 functions:
@@ -32,18 +40,18 @@ functions:
 
 resources:
   Resources:
-    S3BucketFarsetLabsEvents:
+    S3BucketMuxerProducedEventsFarsetLabs:
       DependsOn:
-        - TransformLambdaPermissionS3BucketFarsetLabsEventsS3
+        - TransformLambdaPermissionS3BucketMuxerProducedEventsFarsetLabsS3
       Type: AWS::S3::Bucket
       Properties:
-        BucketName: ${self:custom.bucketName}
+        BucketName: ${self:custom.producerBucket}
         NotificationConfiguration:
           LambdaConfigurations:
             - Event: "s3:ObjectCreated:*"
               Function:
                 "Fn::GetAtt": [ TransformLambdaFunction, Arn ]
-    TransformLambdaPermissionS3BucketFarsetLabsEventsS3:
+    TransformLambdaPermissionS3BucketMuxerProducedEventsFarsetLabsS3:
       DependsOn:
         - TransformLambdaFunction
       Type: AWS::Lambda::Permission
@@ -52,4 +60,4 @@ resources:
           "Fn::GetAtt": [ TransformLambdaFunction, Arn ]
         Action: "lambda:InvokeFunction"
         Principal: "s3.amazonaws.com"
-        SourceArn: "arn:aws:s3:::${self:custom.bucketName}"
+        SourceArn: "arn:aws:s3:::${self:custom.producerBucket}"

--- a/lambdas/farsetlabs/utils.js
+++ b/lambdas/farsetlabs/utils.js
@@ -1,0 +1,38 @@
+const {
+  createHash,
+  getDateTimePathFor,
+  setInS3
+} = require("aws-lambda-data-utils");
+
+const uploadTo = function(bucketName, createFilename, data) {
+  const fileContents = JSON.stringify(data);
+  const today = new Date();
+  const hash = createHash(fileContents);
+  const prefix = getDateTimePathFor(today);
+  const filename = createFilename(today, hash);
+  const filePath = `${prefix}/${filename}`;
+
+  return setInS3(prefix, bucketName, filePath, fileContents);
+};
+
+const uploadData = function(bucketName, calendarData) {
+  return uploadTo(
+    bucketName,
+    (today, hash) =>
+      `farset-labs-calendar__${today.valueOf()}__${hash}.json`,
+    calendarData
+  );
+};
+
+const addYear = (date) => new Date(date.setFullYear(date.getFullYear() + 1));
+
+const convert = params =>
+  Object.entries(params)
+    .map(([key, val]) => `${key}=${val}`)
+    .join("&");
+
+module.exports = {
+  uploadData,
+  addYear,
+  convert
+}


### PR DESCRIPTION
### What's Changed

Implementation of the Farset Labs event transformer.
Relies on an existing `muxer-transformed-events` bucket being available, into which transformed events files are added. In the future, this bucket will be created by the publisher lambda.
Event structure is validated against the event schema. For future work, the console log warning should be converted into a common instrumentations format so that it can be tracked / alerted on.

This PR also:
 - Updates the name of the service and DRYs use into the config file
 - Updates the bucket names and DRYs use into the config file
 - Extracts common functionality to util file

As the other lambda groups are updated to add transformers, the above changes will also be made to those.

---

Example payload now saved in S3: https://gist.github.com/alistairjcbrown/c3e2d325b69e71f0ca3c88fa16c7e558

A single event will look like:
```json
{
  "name": "Code Co-op NI",
  "description": "https://www.meetup.com/CodeCoop-NI",
  "url": "https://www.farsetlabs.org.uk/events/#upcoming-events",
  "times": {
    "start": {
      "utc": "2018-10-18T18:00:00.000Z",
      "timezone": "Europe/London"
    },
    "end": {
      "utc": "2018-10-18T20:00:00.000Z",
      "timezone": "Europe/London"
    },
    "duration": 7200000
  },
  "topics": [],
  "venue": {
    "name": "Farset Labs",
    "latitude": "54.592826",
    "longitude": "-5.940666",
    "address": "Weavers Court, Linfield Road, BT12 5GH",
    "city": "Belfast",
    "country": "GB"
  },
  "created_at": "2018-05-21T10:21:12.000Z",
  "last_updated": "2018-05-21T10:33:48.120Z",
  "source_data": {
    "name": "farsetlabs-calendar",
    "id": "4b471u35laf5kgeegsjjku3lu8_20181018T180000Z"
  }
}
```