### PR TITLE
Update eventbrite lambda in preparation for transformer implementation

### DIFF
--- a/lambdas/eventbrite/config.js
+++ b/lambdas/eventbrite/config.js
@@ -1,9 +1,6 @@
-const EVENTBRITE_TECH_CATEGORY = 102;
+const { convert } = require("./utils");
 
-const convert = params =>
-  Object.entries(params)
-    .map(([key, val]) => `${key}=${val}`)
-    .join("&");
+const EVENTBRITE_TECH_CATEGORY = 102;
 
 const eventsApi = "https://www.eventbriteapi.com/v3/events/search/";
 const eventsParams = page =>
@@ -19,6 +16,9 @@ const eventsParams = page =>
   });
 
 module.exports = {
-  bucketName: "eventbrite-events-bucket",
+  buckets: () => ({
+    producerBucket: "muxer-produced-events-eventbrite",
+    eventsBucket: "muxer-transformed-events"
+  }),
   getEventsUrl: ({ page }) => `${eventsApi}?${eventsParams(page)}`
 };

--- a/lambdas/eventbrite/package-lock.json
+++ b/lambdas/eventbrite/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "pull-eventbrite-events",
+  "name": "muxer-pull-events-eventbrite",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/lambdas/eventbrite/package.json
+++ b/lambdas/eventbrite/package.json
@@ -1,8 +1,7 @@
 {
-  "name": "pull-eventbrite-events",
+  "name": "muxer-pull-events-eventbrite",
   "version": "1.0.0",
   "description": "Pull eventbrite.com events data",
-  "main": "handler.js",
   "dependencies": {
     "aws-lambda-data-utils": "^1.0.0"
   }

--- a/lambdas/eventbrite/serverless.yml
+++ b/lambdas/eventbrite/serverless.yml
@@ -1,4 +1,7 @@
-service: pull-eventbrite-events
+service: ${file(./package.json):name}
+
+custom: ${file(./config.js):buckets}
+
 provider:
   name: aws
   runtime: nodejs8.10
@@ -10,19 +13,20 @@ provider:
         Fn::Join:
           - ""
           - - "arn:aws:s3:::"
-            - "Ref" : "EventbriteEventsBucket"
+            - ${self:custom.producerBucket}
             - "/*"
 functions:
   produce:
-    handler: handler.produce
+    handler: handlers/producer.produce
     events:
       - schedule: rate(1 hour)
     environment:
       TZ: Europe/Belfast
       EVENTBRITE_API_TOKEN: ${ssm:eventbriteApiToken~true}
+
 resources:
   Resources:
-    EventbriteEventsBucket:
+    S3BucketMuxerProducedEventsEventbrite:
       Type: AWS::S3::Bucket
       Properties:
-        BucketName: eventbrite-events-bucket
+        BucketName: ${self:custom.producerBucket}

--- a/lambdas/eventbrite/utils.js
+++ b/lambdas/eventbrite/utils.js
@@ -15,8 +15,6 @@ const uploadTo = function(bucketName, createFilename, data) {
   return setInS3(prefix, bucketName, filePath, fileContents);
 };
 
-const addYear = (date) => new Date(date.setFullYear(date.getFullYear() + 1));
-
 const convert = params =>
   Object.entries(params)
     .map(([key, val]) => `${key}=${val}`)
@@ -24,6 +22,5 @@ const convert = params =>
 
 module.exports = {
   uploadTo,
-  addYear,
   convert
 }

--- a/lambdas/farsetlabs/handlers/producer.js
+++ b/lambdas/farsetlabs/handlers/producer.js
@@ -2,7 +2,16 @@
 
 const { getFromWeb } = require("aws-lambda-data-utils");
 const { buckets, getEventsUrl } = require("../config");
-const { uploadData } = require("../utils");
+const { uploadTo } = require("../utils");
+
+const uploadData = function(bucketName, calendarData) {
+  return uploadTo(
+    bucketName,
+    (today, hash) =>
+      `farset-labs-calendar__${today.valueOf()}__${hash}.json`,
+    calendarData
+  );
+};
 
 module.exports.produce = async (event, context, callback) => {
   try {


### PR DESCRIPTION
### What's Changed

Based on the work on the Farset Labs Calendar lambda, this follow the same pattern
 - Functionality moved to `handlers/` directory
 - Utils file creation with common code (later to be extracted)
 - Service name and bucket names consolidated to configuration file and pulled into serverless config, with common naming convention
 - Don't return `event` object in callback, just file paths as message

There will be a follow-up PR to apply this to the meetupcom lambda.