### PR TITLE
Update meetupcom lambda in preparation for transformer implementation

### DIFF
--- a/lambdas/meetupcom/config.js
+++ b/lambdas/meetupcom/config.js
@@ -1,9 +1,6 @@
-const MEETUPCOM_TECH_CATEGORY = 34;
+const { convert } = require("./utils");
 
-const convert = params =>
-  Object.entries(params)
-    .map(([key, val]) => `${key}=${val}`)
-    .join("&");
+const MEETUPCOM_TECH_CATEGORY = 34;
 
 const groupsApi = "https://api.meetup.com/find/groups";
 const groupsParams = convert({
@@ -29,7 +26,10 @@ const eventsParams = convert({
 });
 
 module.exports = {
-  bucketName: "meetupcom-events-bucket",
+  buckets: () => ({
+    producerBucket: "muxer-produced-events-meetupcom",
+    eventsBucket: "muxer-transformed-events"
+  }),
   getGroupsUrl: () => `${groupsApi}?${groupsParams}`,
   getEventsUrl: slug => `${eventsApi(slug)}?${eventsParams}`
 };

--- a/lambdas/meetupcom/package-lock.json
+++ b/lambdas/meetupcom/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "pull-meetupcom-events",
+  "name": "muxer-pull-events-meetupcom",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/lambdas/meetupcom/package.json
+++ b/lambdas/meetupcom/package.json
@@ -1,8 +1,7 @@
 {
-  "name": "pull-meetupcom-events",
+  "name": "muxer-pull-events-meetupcom",
   "version": "1.0.0",
   "description": "Pull meetup.com events data",
-  "main": "handler.js",
   "dependencies": {
     "aws-lambda-data-utils": "^1.0.0"
   }

--- a/lambdas/meetupcom/serverless.yml
+++ b/lambdas/meetupcom/serverless.yml
@@ -1,4 +1,7 @@
-service: pull-meetupcom-events
+service: ${file(./package.json):name}
+
+custom: ${file(./config.js):buckets}
+
 provider:
   name: aws
   runtime: nodejs8.10
@@ -10,19 +13,20 @@ provider:
         Fn::Join:
           - ""
           - - "arn:aws:s3:::"
-            - "Ref" : "MeetupcomEventsBucket"
+            - ${self:custom.producerBucket}
             - "/*"
 functions:
   produce:
-    handler: handler.produce
+    handler: handlers/producer.produce
     events:
       - schedule: rate(1 hour)
     environment:
       TZ: Europe/Belfast
       MEETUPCOM_API_TOKEN: ${ssm:meetupcomApiToken~true}
+
 resources:
   Resources:
-    MeetupcomEventsBucket:
+    S3BucketMuxerProducedEventsMeetupcom:
       Type: AWS::S3::Bucket
       Properties:
-        BucketName: meetupcom-events-bucket
+        BucketName: ${self:custom.producerBucket}

--- a/lambdas/meetupcom/utils.js
+++ b/lambdas/meetupcom/utils.js
@@ -1,0 +1,26 @@
+const {
+  createHash,
+  getDateTimePathFor,
+  setInS3
+} = require("aws-lambda-data-utils");
+
+const uploadTo = function(bucketName, createFilename, data) {
+  const fileContents = JSON.stringify(data);
+  const today = new Date();
+  const hash = createHash(fileContents);
+  const prefix = getDateTimePathFor(today);
+  const filename = createFilename(today, hash);
+  const filePath = `${prefix}/${filename}`;
+
+  return setInS3(prefix, bucketName, filePath, fileContents);
+};
+
+const convert = params =>
+  Object.entries(params)
+    .map(([key, val]) => `${key}=${val}`)
+    .join("&");
+
+module.exports = {
+  uploadTo,
+  convert
+}


### PR DESCRIPTION
### What's Changed

Based on the work on the Farset Labs Calendar lambda and Eventbrite lambda (PR #461), this follows the same pattern
 - Functionality moved to `handlers/` directory
 - Utils file creation with common code (later to be extracted)
 - Service name and bucket names consolidated to configuration file and pulled into serverless config, with common naming convention
 - Don't return `event` object in callback, just file paths as message

This completes the standardisation of the lambda setup (for now), with the next work focusing on transformer implementation.