### PR TITLE
Update Farset Labs calendar lambda for fixes and readme updates

### DIFF
--- a/lambdas/README.md
+++ b/lambdas/README.md
@@ -189,7 +189,7 @@ changes
 
 ### Producer
 
-This lambda pulls data from the Farset Labs calendar iCalendar endpoint and
+This lambda pulls data from the Farset Labs Google calendar JSON endpoint and
 saves it to S3.
 
 You will need to create a new entry in the AWS Systems Manager Parameter store
@@ -206,7 +206,7 @@ functionality of the lambda.
 #### `farsetlabs:producer:invoke`
 
 Invoke the lambda on AWS. As this lambda creates files in S3, you should see new
-ICS files created with the data pulled from the Farset Labs calendar.
+JSON files created with the data pulled from the Farset Labs calendar.
 
 #### `farsetlabs:producer:invoke-local`
 
@@ -228,7 +228,7 @@ Pulls the logs from cloudwatch of the last lambda run. Useful for debugging.
 
 ### Transformer
 
-This lambda takes the Farset Labs calendar iCalendar data which has been
+This lambda takes the Farset Labs Google calendar JSON data which has been
 saved to S3, transforms it into a standardised format and saves it back to S3.
 
 This lambda is triggered by the creation of the source file by the producer

--- a/lambdas/farsetlabs/handlers/producer.js
+++ b/lambdas/farsetlabs/handlers/producer.js
@@ -19,7 +19,7 @@ module.exports.produce = async (event, context, callback) => {
     const { producerBucket } = buckets();
     const filePath = (await uploadData(producerBucket, calendarData)).key;
 
-    callback(null, { message: filePath });
+    callback(null, { message: [filePath] });
   } catch (err) {
     callback(err, null);
   }

--- a/lambdas/farsetlabs/handlers/transformer.js
+++ b/lambdas/farsetlabs/handlers/transformer.js
@@ -4,7 +4,7 @@ const { getFromS3 } = require("aws-lambda-data-utils");
 const { validate } = require("jsonschema");
 const eventSchema = require("./schemas/event-schema");
 const { buckets } = require("../config");
-const { uploadData } = require("../utils");
+const { uploadTo } = require("../utils");
 
 const transformEvent = function (defaults, {
   id, summary, description, start, end, created, updated
@@ -46,6 +46,15 @@ const transformEvent = function (defaults, {
 };
 
 const isValidEvent = (event) => validate(event, eventSchema).errors.length === 0;
+
+const uploadData = function(bucketName, calendarData) {
+  return uploadTo(
+    bucketName,
+    (today, hash) =>
+      `farset-labs-calendar__${today.valueOf()}__${hash}.json`,
+    calendarData
+  );
+};
 
 module.exports.transform = async (event, context, callback) => {
   try {


### PR DESCRIPTION
### What's Changed

 - Update readme for Farset Labs calendar lambda to reference JSON and Google API instead of iCalendar
 - Standardise on always returning array of file paths
 - Previous removal of `uploadData` from the utils had neglected that it was used by the transformer - this adds it to the transformer file. It's the same as the one in the producer, but most likely the file paths for transformers will be updated independently, once a standard is decided upon.