### PR TITLE
Fix for caching event requests with url parameters

### DIFF
--- a/services/events/project/api/events.py
+++ b/services/events/project/api/events.py
@@ -151,7 +151,7 @@ def get_single_event(event_id):
 
 
 @events_blueprint.route("/events", methods=["GET"])
-@cache.cached(timeout=1000)
+@cache.cached(timeout=1000, query_string=True)
 def get_all_events():
     """Get all events"""
 


### PR DESCRIPTION
### What's Changed

Fix for cached requests when pagination is used; Allows URL parameters to be memorized to avoid causing all results as a single page.
