### PR TITLE
Removing title casing on event names

### DIFF
--- a/services/client/src/components/event/content.js
+++ b/services/client/src/components/event/content.js
@@ -1,6 +1,5 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { formatTitle } from "utils/format";
 import TimeToEvent from "./time-to-event";
 import EventTime from "./event-time";
 import styles from "./styles/content";
@@ -15,7 +14,7 @@ const Content = ({ name, start, url, category }) => (
         target="_blank"
         rel="noopener noreferrer"
       >
-        {formatTitle(name)}
+        {name}
       </a>
     </div>
     <div className="event-time">


### PR DESCRIPTION
### What's Changed

Removes title case formatting from event names to improve readability. 

| Before | After |
| ----- | ------ |
| <img width="1677" alt="screen shot 2018-10-16 at 20 23 35" src="https://user-images.githubusercontent.com/1443700/47042137-77c2aa00-d182-11e8-9ee8-60a2d45b2259.png"> |  <img width="1680" alt="screen shot 2018-10-16 at 20 23 52" src="https://user-images.githubusercontent.com/1443700/47042160-814c1200-d182-11e8-95ec-25e7c30fb263.png"> | 

### Technical Description

TitleCase was often stripping connecting characters and delimiters which often resulted in nonsensical event names. Removing title case is a short-term solution until a data cleaning step can be added. 