### PR TITLE
Adding css background color to Events spinner

### DIFF
--- a/services/client/src/App.js
+++ b/services/client/src/App.js
@@ -30,6 +30,7 @@ const App = () => (
           margin-left: auto;
           margin-right: auto;
           width: 100%;
+          background: white;
         }
 
         @media (min-width: 576px) {


### PR DESCRIPTION
### What's Changed

Adds a css white background to the events spinner to make the spinner look less jarring when it loads at the bottom of the page.

| Before | After |
| ----- | ------ |
| <img width="969" alt="screen shot 2018-10-18 at 22 30 07" src="https://user-images.githubusercontent.com/1443700/47185847-9661a600-d326-11e8-8abd-0f67ab69d014.png"> | <img width="970" alt="screen shot 2018-10-18 at 22 29 34" src="https://user-images.githubusercontent.com/1443700/47185817-77631400-d326-11e8-8ef6-2e348a63e8dc.png"> |