### PR TITLE
Fix for only allowing approved subdomains

### DIFF
--- a/services/client/src/pages/events/components/events.js
+++ b/services/client/src/pages/events/components/events.js
@@ -14,14 +14,23 @@ class Events extends Component {
   state = {};
 
   componentDidMount() {
+    this.setLocationFromSubdomain();
+  }
+
+  setLocationFromSubdomain = () => {
     const { setLocation } = this.props;
 
     if (parsedDomain) {
-      if (parsedDomain.subdomain) {
-        setLocation(parsedDomain.subdomain);
+      const { subdomain } = parsedDomain;
+      if (subdomain) {
+        if (
+          _.includes(["belfast", "glasgow", "edinburgh", "dublin"], subdomain)
+        ) {
+          setLocation(subdomain);
+        }
       }
     }
-  }
+  };
 
   fetch = () => {
     const { fetchData, url, params, location } = this.props;


### PR DESCRIPTION
### What's Changed

A quick fix to default back to `Belfast` if the subdomain cannot be recognized as an approved subdomain. 

| Before | After |
| -------- | ----------| 
|  |  | 
