### PR TITLE
footer overlay style fix

### DIFF
--- a/services/client/src/components/footer/styles.js
+++ b/services/client/src/components/footer/styles.js
@@ -11,6 +11,7 @@ export default css`
     margin-bottom: 0;
     position: sticky;
     bottom: 0;
+    z-index: 4;
   }
 
   @media (min-width: 992px) {


### PR DESCRIPTION
### What's Changed

--> On smaller devices where the calendar page requires scrolling, the calendar content appears over the top of the footer.

Increasing z-index of footer content

### Technical Description

--> Issue can be seen live in chrome dev-tools by changing the device emulator to IPhone5/SE.
--> z-index set to 4 as that was all that was necessary - this value can be increased if necessary.

![image](https://user-images.githubusercontent.com/4324765/52596348-0355fa00-2e48-11e9-8a11-d710506eba1e.png)

